### PR TITLE
Rename exclusive to double_count

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -194,37 +194,37 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
   };
 
   const updateReqs = (reqs: [string, requirements[]][], courseObj) => {
-    // exclusive check:
-    // If exclusive is undefined, the course may double count for any number of distributions
-    // If exclusive is string[], the specified distributions / fine requirements are 'whitelisted'
-    // When a course satisfies a distribution, exclusive takes the value of distribution.exclusive
+    // double_count check:
+    // If double_count is undefined, the course may double count for any number of distributions
+    // If double_count is string[], the specified distributions / fine requirements are 'whitelisted'
+    // When a course satisfies a distribution, double_count takes the value of distribution.double_count
     if (!courseObj) return;
-    let distExclusive: string[] | undefined = undefined; // initial value
+    let distDoubleCount: string[] | undefined = undefined; // initial value
     reqs.forEach((reqGroup, i) => {
       let req = reqGroup[1][0]; // general distribution
       if (
-        (!distExclusive || distExclusive.includes(req.name)) &&
+        (!distDoubleCount || distDoubleCount.includes(req.name)) &&
         (req.fulfilled_credits < req.required_credits ||
           (req.required_credits === 0 && req.fulfilled_credits === 0)) &&
         checkRequirementSatisfied(req, courseObj)
       ) {
         reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
-        distExclusive = req.exclusive; // set exclusive, if any
-        let fineExclusive: string[] | undefined = undefined;
+        distDoubleCount = req.double_count; // set double_count, if any
+        let fineDoubleCount: string[] | undefined = undefined;
         reqGroup[1].forEach((req: requirements, j: number) => {
           // fine reqs
           if (j !== 0) {
             // 0 is the general distribution, not fine req
             let fineReq = reqGroup[1][j];
             if (
-              (!fineExclusive || fineExclusive.includes(fineReq.name)) &&
+              (!fineDoubleCount || fineDoubleCount.includes(fineReq.name)) &&
               (fineReq.fulfilled_credits < fineReq.required_credits ||
                 (fineReq.required_credits === 0 &&
                   fineReq.fulfilled_credits === 0)) &&
               checkRequirementSatisfied(fineReq, courseObj)
             ) {
               reqs[i][1][j].fulfilled_credits += parseInt(courseObj.credits);
-              fineExclusive = fineReq.exclusive;
+              fineDoubleCount = fineReq.double_count;
             }
           }
         });

--- a/lib/components/dashboard/degree-info/distributionFunctions.tsx
+++ b/lib/components/dashboard/degree-info/distributionFunctions.tsx
@@ -6,7 +6,7 @@ export type requirements = {
   required_credits: number;
   fulfilled_credits: number;
   description: string;
-  exclusive?: string[];
+  double_count?: string[];
   pathing?: number;
   wi?: boolean;
 };
@@ -203,7 +203,7 @@ export const getRequirements = (major: Major) => {
       fulfilled_credits: 0,
       description: element.description,
       pathing: element.pathing,
-      exclusive: element.exclusive,
+      double_count: element.double_count,
     };
     allReq.push(general);
     if (element.fine_requirements !== undefined) {
@@ -216,7 +216,7 @@ export const getRequirements = (major: Major) => {
             required_credits: fine.required_credits,
             fulfilled_credits: 0,
             description: '',
-            exclusive: fine.exclusive,
+            double_count: fine.double_count,
           },
         ];
       });

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -159,7 +159,6 @@ export type Distribution = {
   criteria: string;
   fine_requirements?: FineReq[];
   user_select?: boolean;
-  double_count?: boolean;
   exception?: string;
   planned_credits: number;
   courses: string[];
@@ -194,7 +193,7 @@ export type FineReq = {
   required_credits: number;
   description: string;
   criteria: string;
-  exclusive?: string[];
+  double_count?: string[];
 };
 
 export type DistributionObj = {
@@ -205,9 +204,8 @@ export type DistributionObj = {
   criteria: string;
   fine_requirements?: FineReq[];
   user_select?: boolean;
-  double_count?: boolean;
+  double_count?: string[];
   exception?: string;
-  exclusive?: string[];
   pathing?: number;
 };
 

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -113,7 +113,7 @@ const baCogSci: Major = {
         'Neuroscience',
       criteria:
         'COGS-COGPSY[T]^OR^COGS-LING[T]^OR^COGS-COMPCG[T]^OR^COGS-NEURO[T]^OR^COGS-PHLMND[T]',
-      exclusive: [
+        double_count: [
         'Two Focal Areas',
         'Math',
         'Humanities (H) Distribution',
@@ -157,7 +157,7 @@ const baCogSci: Major = {
         'Four courses in each of the two chosen focal areas. Research, readings, and practica courses do not qualify.',
       criteria:
         'COGS-COGPSY[T]^OR^COGS-LING[T]^OR^COGS-COMPCG[T]^OR^COGS-NEURO[T]^OR^COGS-PHLMND[T]',
-      exclusive: [
+      double_count: [
         'One Course from each Focal Area',
         'Math',
         'Humanities (H) Distribution',
@@ -213,7 +213,7 @@ const baCogSci: Major = {
         'Up to three credits of cognitive science research, readings, or practica may apply.',
       criteria:
         '(COGS-COGPSY[T]^OR^COGS-LING[T]^OR^COGS-COMPCG[T]^OR^COGS-NEURO[T]^OR^COGS-PHLMND[T])^AND^(Upper Level[L])',
-      exclusive: [
+      double_count: [
         'Math',
         'Humanities (H) Distribution',
         'Social Sciences (S) Distribution',
@@ -270,7 +270,7 @@ const baCogSci: Major = {
         'The student must complete at least 9 credits in the Humanities (H) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'H[A]',
-      exclusive: [
+      double_count: [
         'One Course from each Focal Area',
         'Two Focal Areas',
         'Upper Level Electives',
@@ -287,7 +287,7 @@ const baCogSci: Major = {
         'The student must complete at least 9 credits in the Social Science (S) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'S[A]',
-      exclusive: [
+      double_count: [
         'One Course from each Focal Area',
         'Two Focal Areas',
         'Upper Level Electives',
@@ -304,7 +304,7 @@ const baCogSci: Major = {
         'The student must complete at least 9 credits in any of the other areas: Natural Sciences (N), Engineering (E) and/or Quantitative (Q). ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'N[A]^OR^E[A]^OR^Q[A]',
-      exclusive: [
+      double_count: [
         'One Course from each Focal Area',
         'Two Focal Areas',
         'Upper Level Electives',
@@ -452,7 +452,7 @@ const baEcon: Major = {
         'major degree requirement</a> section on the department website.',
       criteria:
         'AS.180.101[C]^OR^AS.180.102[C]^OR^AS.180.301[C]^OR^AS.108.401[C]^OR^AS.180.302[C]',
-      exclusive: [
+      double_count: [
         'Humanities (H) Distribution',
         'Social Science (S) Distribution',
         'Other (N/E/Q) Distribution',
@@ -499,7 +499,7 @@ const baEcon: Major = {
         'All courses in this category must be offered by the Economics Department. Three courses must be taken at the 200 level, ' +
         'and two must be taken at the 300 level.',
       criteria: 'AS Economics[D]',
-      exclusive: [
+      double_count: [
         'Humanities (H) Distribution',
         'Social Science (S) Distribution',
         'Other (N/E/Q) Distribution',
@@ -525,7 +525,7 @@ const baEcon: Major = {
       description:
         'Students must complete the math requirement for the major by taking Calculus I (AS.110.106 OR AS.110.108).',
       criteria: 'AS.110.106[C]^OR^AS.110.108[C]',
-      exclusive: [
+      double_count: [
         'Humanities (H) Distribution',
         'Social Science (S) Distribution',
         'Other (N/E/Q) Distribution',
@@ -543,7 +543,7 @@ const baEcon: Major = {
         'AS.280.345 Public Health Biostatistics',
       criteria:
         'EN.553.111[C]^OR^EN.553.112[C]^OR^EN.553.211[C]^OR^EN.553.310[C]^OR^EN.553.311[C]^OR^EN.553.420[C]^OR^EN.553.430[C]^OR^AS.280.345[C]',
-      exclusive: [
+      double_count: [
         'Humanities (H) Distribution',
         'Social Science (S) Distribution',
         'Other (N/E/Q) Distribution',
@@ -559,7 +559,7 @@ const baEcon: Major = {
         'The student must complete at least 9 credits in the Humanities (H) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'H[A]',
-      exclusive: [
+      double_count: [
         'Economics Core',
         'Economics Electives',
         'Mathematics',
@@ -576,7 +576,7 @@ const baEcon: Major = {
         'The student must complete at least 9 credits in the Social Science (S) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'S[A]',
-      exclusive: [
+      double_count: [
         'Economics Core',
         'Economics Electives',
         'Mathematics',
@@ -593,7 +593,7 @@ const baEcon: Major = {
         'The student must complete at least 9 credits in any of the other areas: Natural Sciences (N), Engineering (E) and/or Quantitative (Q). ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'N[A]^OR^E[A]^OR^Q[A]',
-      exclusive: [
+      double_count: [
         'Economics Core',
         'Economics Electives',
         'Mathematics',
@@ -635,7 +635,7 @@ const bsBME: Major = {
         'EN.580.111[C]^OR^EN.580.151[C]^OR^EN.580.153[C]^OR^EN.580.221[C]^OR^EN.580.241[C]^OR^EN.580.242[C]^OR^EN.580.243[C]^OR^' +
         'EN.580.244[C]^OR^EN.580.246[C]^OR^EN.580.248[C]^OR^EN.580.475[C]^OR^EN.580.477[C]^OR^EN.580.485[C]^OR^EN.580.487[C]^OR^' +
         'EN.580.424[C]^OR^EN.580.427[C]^OR^EN.580.452[C]^OR^EN.580.453[C]^OR^EN.580.454[C]^OR^EN.580.494[C]',
-      exclusive: [
+      double_count: [
         'Focus Area',
         'Design',
         'Humanities and Social Sciences',
@@ -758,7 +758,7 @@ const bsBME: Major = {
       criteria:
         'AS.171.101[C]^OR^AS.171.107[C]^OR^AS.171.102[C]^OR^AS.171.108[C]^OR^AS.173.111[C]^OR^AS.173.112[C]' +
         '^OR^AS.030.101[C]^OR^AS.030.102[C]^OR^AS.030.105[C]^OR^AS.030.106[C]',
-      exclusive: ['Humanities and Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities and Social Sciences', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -820,7 +820,7 @@ const bsBME: Major = {
       criteria:
         'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.202[C]^OR^AS.110.211[C]^OR^EN.553.291[C]' +
         '^OR^EN.553.310[C]^OR^EN.553.311[C]^OR^EN.553.413[C]^OR^EN.553.430[C]^OR^EN.553.433[C]^OR^EN.560.348[C]',
-      exclusive: [
+      double_count: [
         'Focus Area',
         'Humanities and Social Sciences',
         'Writing Intensive',
@@ -868,7 +868,7 @@ const bsBME: Major = {
       description:
         'Students are required to take at least one semester of programming from a select set of gateway computing courses.',
       criteria: 'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -889,7 +889,7 @@ const bsBME: Major = {
         ' determine the best combination of classes for you:',
       criteria:
         'BMED-BDS[T]^OR^BMED-CM[T]^OR^BMED-GSB[T]^OR^BMED-IMD[T]^OR^BMED-IMMU[T]^OR^BMED-NE[T]^OR^BMED-TCTE[T]',
-      exclusive: [
+      double_count: [
         'Biomedical Core',
         'Mathematics',
         'Design',
@@ -946,7 +946,7 @@ const bsBME: Major = {
         '(EN.580.456[C]^OR^EN.580.457[C])^OR^(EN.580.471[C]^OR^EN.580.571[C])^OR^' +
         '(EN.580.480[C]^OR^EN.580.481[C])^OR^(EN.580.580[C]^OR^EN.580.581[C])^OR^' +
         '(EN.601.455[C]^OR^EN.601.456[C])^OR^(EN.580.437[C]^OR^EN.580.438[C])',
-      exclusive: [
+      double_count: [
         'Focus Area',
         'Humanities and Social Sciences',
         'Writing Intensive',
@@ -1040,7 +1040,7 @@ const bsBME: Major = {
       min_credits_per_course: 1,
       description: 'Select 9 credits from any area.',
       criteria: 'H[A]^OR^S[A]^OR^Q[A]^OR^N[A]^OR^E[A]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
     },
     {
       name: 'Humanities and Social Sciences',
@@ -1050,7 +1050,7 @@ const bsBME: Major = {
         'Select courses to form a coherent program, relevant to the student’s goals. One course in which ethical and social ' +
         'issues related to technology or medicine is recommended.',
       criteria: 'H[A]^OR^S[A]',
-      exclusive: [
+      double_count: [
         'Biomedical Core',
         'Focus Area',
         'Design',
@@ -1072,7 +1072,7 @@ const bsBME: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
       criteria: 'Written Intensive[W]',
-      exclusive: [
+      double_count: [
         'Biomedical Core',
         'Focus Area',
         'Design',
@@ -1710,7 +1710,7 @@ const baIS: Major = {
         'course in American politics (AP) <br /> One course in political theory (PT) <br /> One gateway course',
       criteria:
         'INST-IR[T]^OR^INST-CP[T]^OR^INST-AP[T]^OR^INST-PT[T]^OR^AS.070.295[C]^OR^AS.190.108[C]^OR^AS.190.111[C]^OR^(AS.230.150[C]^AND^Fall 2019[Y])',
-      exclusive: [
+      double_count: [
         'Economics',
         'Foreign Language',
         'History',
@@ -1764,7 +1764,7 @@ const baIS: Major = {
         'Note: both Elements of Macroeconomics and Elements of Microeconomics must be ' +
         'completed by the end of the sophomore year.',
       criteria: 'INST-ECON[T]^OR^AS Economics[D]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Foreign Language',
         'History',
@@ -1821,7 +1821,7 @@ const baIS: Major = {
         'course advanced coursework requirement.',
       criteria:
         'AS Center for Language Education[D]^OR^AS Modern Languages and Literatures[D]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Economics',
         'History',
@@ -1840,7 +1840,7 @@ const baIS: Major = {
         'https://krieger.jhu.edu/internationalstudies/undergraduate/requirements/',
       criteria: '^NOT^AS.180.101[C]^NOT^AS.180.102[C]',
       user_select: true,
-      exclusive: [
+      double_count: [
         'Humanities (H) Distribution',
         'Social Science (S) Distribution',
         'Other (N/E/Q) Distribution',
@@ -1856,7 +1856,7 @@ const baIS: Major = {
         'One introductory course at the 100-level in the JHU History Department ' +
         '(e.g., AS.100.1xx).\n\tFour courses designated INST-GLOBAL in the course description.',
       criteria: '(AS History[D]^AND^100[L])^OR^INST-GLOBAL[T]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Economics',
         'Foreign Language',
@@ -1889,7 +1889,7 @@ const baIS: Major = {
         'The student must complete at least 9 credits in the Humanities (H) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'H[A]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Economics',
         'Foreign Language',
@@ -1907,7 +1907,7 @@ const baIS: Major = {
         'The student must complete at least 9 credits in the Social Science (S) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'S[A]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Economics',
         'Foreign Language',
@@ -1925,7 +1925,7 @@ const baIS: Major = {
         'The student must complete at least 9 credits in any of the other areas: Natural Sciences (N), Engineering (E) and/or Quantitative (Q). ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'N[A]^OR^E[A]^OR^Q[A]',
-      exclusive: [
+      double_count: [
         'Political Science',
         'Economics',
         'Foreign Language',
@@ -2195,7 +2195,7 @@ const bsCS_Old: Major = {
         "For more information please visit the <a href='https://www.cs.jhu.edu/undergraduate-studies/academics/ugrad-advising-manual/'>" +
         'major degree requirement</a> section on the department website.',
       criteria: 'EN Computer Science[D]^OR^EN.500.112[C]^OR^EN.660.400[C]',
-      exclusive: [
+      double_count: [
         'Mathematics',
         'Humanities/Social Sciences',
         'Writing Intensive',
@@ -2208,7 +2208,7 @@ const bsCS_Old: Major = {
             'EN.660.400 Practical Ethics for Future Leaders',
           required_credits: 1,
           criteria: 'EN.601.104[C]^OR^EN.660.400[C]',
-          exclusive: ['N/A'],
+          double_count: ['N/A'],
         },
         {
           description:
@@ -2250,7 +2250,7 @@ const bsCS_Old: Major = {
             '<b>Intro Algorithms</b> <br /> EN.601.433 Intro Algorithms',
           required_credits: 3,
           criteria: 'EN.601.433[C]',
-          exclusive: ['N/A'],
+          double_count: ['N/A'],
         },
         {
           description:
@@ -2259,7 +2259,7 @@ const bsCS_Old: Major = {
             'At least one course in two different classification areas (Applications, Reasoning, Software, Systems) must be chosen in addition to Theory (Algorithms).', // TODO: Question: How to include this requirement?: SEPARATE DISTRIBUTION PATHING
           required_credits: 13,
           criteria: 'EN Computer Science[D]^AND^Upper Level Undergraduate[L]',
-          exclusive: [
+          double_count: [
             '<b>Team Requirement</b> <br /> ' +
               'Select one course with Program of Study Tag CSCI-TEAM.',
             '<b>CS Electives</b> <br /> ' +
@@ -2276,7 +2276,7 @@ const bsCS_Old: Major = {
             'and create a custom course to satisfy this requirement.',
           required_credits: 8,
           criteria: 'EN Computer Science[D]',
-          exclusive: [
+          double_count: [
             '<b>Team Requirement</b> <br /> ' +
               'Select one course with Program of Study Tag CSCI-TEAM.',
             '<b>Upper Level CS Credits</b> <br /> ' +
@@ -2290,7 +2290,7 @@ const bsCS_Old: Major = {
             'Select one course with Program of Study Tag CSCI-TEAM.',
           required_credits: 3,
           criteria: 'CSCI-TEAM[T]',
-          exclusive: [
+          double_count: [
             '<b>Upper Level CS Credits</b> <br /> ' +
               'At least 13 more upper level CS credits are required. ' +
               'At least one course in two different classification areas (Applications, ' +
@@ -2313,7 +2313,7 @@ const bsCS_Old: Major = {
         'may not count towards these math requirements. Other than Calculus I and II, all the ' +
         'remaining courses must be 200-level or above.',
       criteria: 'AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D]',
-      exclusive: [
+      double_count: [
         'Computer Science',
         'Humanities/Social Sciences',
         'Writing Intensive',
@@ -2355,7 +2355,7 @@ const bsCS_Old: Major = {
       description:
         'At least two semesters of physics or two semesters of chemistry, with the associated laboratories, must be included.',
       criteria: 'N[A]',
-      exclusive: ['Humanities/Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities/Social Sciences', 'Writing Intensive'],
       exception:
         'EN Computer Science[D]^OR^AS Center for Language Education[D]^OR^EN Applied Mathematics & Statistics[D]',
     },
@@ -2369,7 +2369,7 @@ const bsCS_Old: Major = {
         'the writing requirement). Foreign language courses can be counted as well, even if ' +
         'they don’t carry an ‘H’ or ‘S’ designator.',
       criteria: 'H[A]^OR^S[A]',
-      exclusive: [
+      double_count: [
         'Computer Science',
         'Mathematics',
         'Basic Sciences',
@@ -2384,7 +2384,7 @@ const bsCS_Old: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
       criteria: 'Written Intensive[W]',
-      exclusive: [
+      double_count: [
         'Computer Science',
         'Mathematics',
         'Basic Sciences',
@@ -2406,7 +2406,7 @@ const bsCS_Old: Major = {
       min_credits_per_course: 1,
       description: 'These can be any credit bearing courses taken at JHU.',
       criteria: '',
-      exclusive: ['Writing Intensive'],
+      double_count: ['Writing Intensive'],
     },
   ],
 };
@@ -2435,7 +2435,7 @@ const bsCS_New: Major = {
             '<b>Computer Ethics(601.104).</b><p>Practical Ethics for Future Leaders (660.400/406) may be used as a substitute for the computer ethics requirement for the BS program, but does not count towards the CS total credits at all.</p>',
           required_credits: 1,
           criteria: 'EN.600.104[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
-          exclusive: ['N/A'],
+          double_count: ['N/A'],
         },
         {
           description:
@@ -2446,7 +2446,7 @@ const bsCS_New: Major = {
           criteria:
             'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]^OR^EN.601.220[C]^OR^EN.601.226[C]' +
             '^OR^EN.601.229[C]^OR^EN.601.230[C]^OR^EN.601.433[C]^OR^EN.601.231',
-          exclusive: ['N/A'],
+          double_count: ['N/A'],
         },
         {
           description:
@@ -2454,7 +2454,7 @@ const bsCS_New: Major = {
           required_credits: 12,
           criteria:
             'EN Computer Science[D]^AND^Upper Level Undergraduate[L]^NOT^EN.601.433[C]^NOT^EN.601.633[C]',
-          exclusive: [
+          double_count: [
             '<b>One Team(CSCI-TEAM) designated course.</b><p> This Team course may overlap other course ' +
               'requirements, for example to count as both Team and Software.</p>',
             '<b>2 Upper Level Classifications:</b><p>At least one upper level course in two of these four different classification</p> ' +
@@ -2468,7 +2468,7 @@ const bsCS_New: Major = {
           required_credits: 6,
           criteria:
             'CSCI-APPL[T]^OR^CSCI-SYST[T]^OR^CSCI-SOFT[T]^OR^CSCI-RSNG[T]',
-          exclusive: [
+          double_count: [
             '<b>Lower Level Undergraduate:</b><p>500.112/113/114 Gateway Computing or AP Comp Sci A or ' +
               'equivalent<p>601.220 Intermediate Programming</p><p>601.226 Data Structures</p><p>601.229 ' +
               'Computer System Fundamentals</p><p>601.230 Mathematical Foundations for Computer Science, or 601.231 Automata for those grandfathered into the old major</p><p>601.433 Algorithms</p>',
@@ -2482,7 +2482,7 @@ const bsCS_New: Major = {
             'requirements, for example to count as both Team and Software.</p>',
           required_credits: 3,
           criteria: 'CSCI-TEAM[T]',
-          exclusive: [
+          double_count: [
             '<b>Upper Level Undergraduate: </b><p>12 upper level CS credits in addition to the required Algorithms course</p>',
             '<b>2 Upper Level Classifications:</b><p>At least one upper level course in two of these four different classification</p> ' +
               'areas: Applications(CSCI-APPL), Systems(CSCI-SYST), Software(CSCI-SOFT) and Reasoning(CSCI-RSNG)',
@@ -2727,7 +2727,7 @@ const CS_Minor_New: Minor = {
         "For more information please visit the <a href=' https://www.cs.jhu.edu/undergraduate-studies/academics/cs-minor/'>" +
         'minor degree requirement</a> section on the department website.',
       criteria: 'Gateway Computing[N]^OR^EN.601.220[C]^OR^EN.601.226[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -2756,7 +2756,7 @@ const CS_Minor_New: Minor = {
       description:
         '<b>Upper Level Undergraduate: </b><p>9 upper level CS credits that form a cohesive program of study and <b>must be approved by the computer science minor advisor</b>. One way is to choose all three courses within one or two area tag classifications (CSCI-APPL, CSCI-SOFT, CSCI-THRY, CSCI-RSNG, CSCI-SYST)</p>',
       criteria: 'EN Computer Science[D]^AND^Upper Level Undergraduate[L]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           required_credits: 6,
@@ -2793,7 +2793,7 @@ const CS_Minor_New: Minor = {
         '<b>Elective Course. Any CS course >= 601.200 that is at least three credits</b>',
       criteria:
         'EN.601.2[C]^OR^EN.600.2[C]^OR^EN.601.3[C]^OR^EN.600.3[C]^OR^EN.601.4[C]^OR^EN.600.4[C]^OR^EN.601.5[C]^OR^EN.600.5[C]^OR^EN.601.6[C]^OR^EN.600.6[C]^OR^EN.601.7[C]^OR^EN.600.7[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -2824,7 +2824,7 @@ const CS_Minor_Old: Minor = {
         'minor degree requirement</a> section on the department website.',
       criteria:
         'Gateway Computing[N]^OR^EN.601.220[C]^OR^EN.601.226[C]^EN.600.233[C]^OR^EN.601.229[C]^OR^EN.600.271[C]^OR^EN.601.231[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -2857,7 +2857,7 @@ const CS_Minor_Old: Minor = {
       required_credits: 9,
       min_credits_per_course: 3,
       pathing: 1,
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       description:
         '<b>Upper Level Undergraduate: </b><p>9 upper level CS credits that form a cohesive program of study and <b>must be approved by the computer science minor advisor</b>. One way is to choose all three courses within one or two area tag classifications (CSCI-APPL, CSCI-SOFT, CSCI-THRY, CSCI-RSNG, CSCI-SYST)</p>',
       criteria: 'EN Computer Science[D]^AND^Upper Level Undergraduate[L]',
@@ -2915,7 +2915,7 @@ const bsMolCell: Major = {
       criteria:
         'AS.020.303[C]^OR^AS.020.340[C]^OR^AS.020.304[C]^OR^AS.020.306[C]^OR^AS.020.316[C]^OR^AS.020.305[C]' +
         '^OR^AS.020.315[C]^OR^AS.250.253[C]^OR^AS.250.254[C]^OR^AS.020.363[C]',
-      exclusive: [
+      double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
         'Humanities Distribution Requirement',
@@ -2980,7 +2980,7 @@ const bsMolCell: Major = {
       description:
         'Must complete General Chemistry (or AP equivalent) and Organic Chemistry in addition to their respective labs.',
       criteria: 'AS Chemistry[D]',
-      exclusive: [
+      double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
         'Humanities Distribution Requirement',
@@ -3028,7 +3028,7 @@ const bsMolCell: Major = {
       description:
         'Must complete Physics I and II (or AP equivalent) in addition to their respective labs.',
       criteria: 'AS Physics & Astronomy[D]',
-      exclusive: [
+      double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
         'Humanities Distribution Requirement',
@@ -3076,7 +3076,7 @@ const bsMolCell: Major = {
       description: 'Must complete Calculus I and II',
       criteria:
         'AS.110.106[C]^OR^AS.110.108[C]^OR^AS.110.107[C]^OR^AS.110.109[C]^OR^AS.171.113[C]',
-      exclusive: [
+      double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
         'Humanities Distribution Requirement',
@@ -3112,7 +3112,7 @@ const bsMolCell: Major = {
         '4 courses and 12 credits required. One 2 or 3 credit elective must be taken in the Biology Department (AS.020.xxx). ' +
         'See POS-Tag BIOL-UL on SIS for the courses approved by the Director of Undergraduate Studies.',
       criteria: 'BIOL-UL[T]',
-      exclusive: [
+      double_count: [
         'Writing Intensive',
         'Humanities Distribution Requirement',
         'Social Science Distribution Requirement',
@@ -3137,7 +3137,7 @@ const bsMolCell: Major = {
         'AS.020.572[C]^OR^AS.020.597[C]^OR^AS.030.501[C]^OR^AS.030.502[C]^OR^AS.030.503[C]^OR^AS.030.504[C]^OR^AS.030.505[C]^OR^AS.030.506[C]^OR^' +
         'AS.030.507[C]^OR^AS.030.509[C]^OR^AS.030.510[C]^OR^AS.030.521[C]^OR^AS.030.522[C]^OR^AS.030.523[C]^OR^AS.030.524[C]^OR^AS.030.525[C]^OR^' +
         'AS.030.526[C]^OR^AS.030.570[C]^OR^AS.030.597[C]^OR^AS.250.521[C]^OR^AS.250.522[C]^OR^AS.250.574[C]^OR^AS.250.597[C]',
-      exclusive: [
+      double_count: [
         'Biology Core',
         'Writing Intensive',
         'Humanities Distribution Requirement',
@@ -3153,7 +3153,7 @@ const bsMolCell: Major = {
         'The student must complete at least 9 credits in the Humanities (H) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'H[A]',
-      exclusive: [
+      double_count: [
         'Biology Core',
         'Chemistry',
         'Physics',
@@ -3172,7 +3172,7 @@ const bsMolCell: Major = {
         'The student must complete at least 9 credits in the Social Science (S) area. ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'S[A]',
-      exclusive: [
+      double_count: [
         'Biology Core',
         'Chemistry',
         'Physics',
@@ -3191,7 +3191,7 @@ const bsMolCell: Major = {
         'The student must complete at least 9 credits in any of the other areas: Natural Sciences (N), Engineering (E) and/or Quantitative (Q). ' +
         'These credits fulfilling the distribution requirement may overlap with major or minor requirements and the writing-intensive requirement.',
       criteria: 'N[A]^OR^E[A]^OR^Q[A]',
-      exclusive: [
+      double_count: [
         'Biology Core',
         'Chemistry',
         'Physics',
@@ -3250,7 +3250,7 @@ const bsMechE: Major = {
         'or the Applied Mathematics and Statistics department in the Whiting School of Engineering.',
       criteria:
         'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]^OR^EN.553.291[C]^OR^AS.110.201[C]^OR^AS.110.212[C]^OR^AS.110.302[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3290,7 +3290,7 @@ const bsMechE: Major = {
         'EN.553.311 Probability and Statistics for the Biological Sciences and Engineering <br />' +
         'EN.560.348 Probability and Statistics for Civil Engineering',
       criteria: 'EN.553.310[C]^OR^EN.553.311[C]^OR^EN.560.348[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
     },
     {
       name: 'Science',
@@ -3300,7 +3300,7 @@ const bsMechE: Major = {
         'The student must complete all the required science courses.',
       criteria:
         'AS.030.101[C]^OR^EN.171.101[C]^OR^AS.173.111[C]^OR^AS.171.102[C]^OR^AS.173.112[C]',
-      exclusive: ['N/A'],
+      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -3348,7 +3348,7 @@ const bsMechE: Major = {
         'EN.530.334[C]^OR^EN.530.335[C]^OR^EN.530.343[C]^OR^EN.530.344[C]^OR^' +
         'EN.530.352[C]^OR^EN.560.201[C]^OR^EN.560.211[C]^OR^EN.660.361[C]^OR^' +
         'EN Computer Science[D]',
-      exclusive: ['Humanities and Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities and Social Sciences', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -3512,7 +3512,7 @@ const bsMechE: Major = {
       description:
         'The student is required to take part in a capstone design project.',
       criteria: 'EN.530.403[C]^OR^EN.530.404[C]',
-      exclusive: ['Humanities and Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities and Social Sciences', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -3535,7 +3535,7 @@ const bsMechE: Major = {
       description:
         'Select three courses (300-level or higher) in mechanical engineering',
       criteria: '(EN Mechanical Engineering[D])^AND^(Upper Level[L])',
-      exclusive: ['Humanities and Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities and Social Sciences', 'Writing Intensive'],
     },
     {
       name: 'Technical Electives',
@@ -3545,7 +3545,7 @@ const bsMechE: Major = {
         'Select three engineering, quantitative studies, or natural sciences courses at or above the 300-level,' +
         "chosen from any combination of courses in engineering, basic sciences, or mathematics selected in consultation with the student's advisor.",
       criteria: '(N[A]^OR^E[A]^OR^Q[A])^AND^(Upper Level[L])',
-      exclusive: ['Humanities and Social Sciences', 'Writing Intensive'],
+      double_count: ['Humanities and Social Sciences', 'Writing Intensive'],
     },
     {
       name: 'Humanities and Social Sciences',
@@ -3555,7 +3555,7 @@ const bsMechE: Major = {
         'Select courses to form a coherent program, relevant to the student’s goals. One course in which ethical and social ' +
         'issues related to technology or medicine is recommended.',
       criteria: 'H[A]^OR^S[A]',
-      exclusive: [
+      double_count: [
         'Core Engineering',
         'Capstone Design',
         'Mechanical Engineering Electives',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -113,7 +113,7 @@ const baCogSci: Major = {
         'Neuroscience',
       criteria:
         'COGS-COGPSY[T]^OR^COGS-LING[T]^OR^COGS-COMPCG[T]^OR^COGS-NEURO[T]^OR^COGS-PHLMND[T]',
-        double_count: [
+      double_count: [
         'Two Focal Areas',
         'Math',
         'Humanities (H) Distribution',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -316,7 +316,6 @@ const baCogSci: Major = {
       name: 'Writing Intensive',
       required_credits: 12,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'To encourage excellence in writing, across disciplines, the university requires all undergraduates to take a number of writing-intensive courses. ' +
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
@@ -606,7 +605,6 @@ const baEcon: Major = {
       name: 'Writing Intensive',
       required_credits: 12,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'To encourage excellence in writing, across disciplines, the university requires all undergraduates to take a number of writing-intensive courses. ' +
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
@@ -1070,7 +1068,6 @@ const bsBME: Major = {
       name: 'Writing Intensive',
       required_credits: 6,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
@@ -1686,7 +1683,6 @@ const bsCBE: Major = {
       name: 'Writing Intensive',
       required_credits: 6,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
@@ -1942,7 +1938,6 @@ const baIS: Major = {
       name: 'Writing Intensive',
       required_credits: 12,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'To encourage excellence in writing, across disciplines, the university requires all undergraduates to take a number of writing-intensive courses. ' +
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
@@ -2165,7 +2160,6 @@ const bsAMS: Major = {
       name: 'Writing Intensive',
       required_credits: 6,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
@@ -2697,7 +2691,6 @@ const baCS_New: Major = {
       name: 'Writing Intensive',
       required_credits: 12,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'Students are required to fulfill the university’s requirement of four writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
@@ -3212,7 +3205,6 @@ const bsMolCell: Major = {
       name: 'Writing Intensive',
       required_credits: 12,
       min_credits_per_course: 3,
-      double_count: true,
       description:
         'To encourage excellence in writing, across disciplines, the university requires all undergraduates to take a number of writing-intensive courses. ' +
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +


### PR DESCRIPTION
## tl;dr
- removed double_count as a boolean field 
- renamed exclusive as double_count

## Motivation
The field name `exclusive` is misleading, as it is a whitelist of distribution names that CAN overlap. To avoid confusion and improve readability, what used to be `exclusive` is now called `double_count`. What used to be `double_count` is removed, as it served no purpose. 

## Changes made 
- modify distribution and fine requirement schemas 
- reflect change in requirement checking functions 
- replace exclusive and remove double_count in `majors.tsx`

### double_count?: string[]
- undefined or []: the distribution can overlap with any others
  - misleading, but saves us LOTS of typing
- ['N/A']: it may not overlap with any other distributions
- ['A', 'B']: it may overlap with distributions with the name field === 'A' or 'B'
  - in fine requirements, we use the description field 

## Testing 
Locally. No changes in functionality and no errors in console. 