### PR TITLE
Added Math Minor

### DIFF
--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -4491,6 +4491,7 @@ const minorMath: Minor = {
         'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
       criteria:
         'AS Mathematics[D]^AND^(200[L]^OR^300[L])',
+      double_count: [],
     },
     {
       name: '300-Level or Above Courses',
@@ -4505,7 +4506,7 @@ const minorMath: Minor = {
         {
           required_credits: 12,
           description:
-            'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
+            '<b>DEFAULT PATH:</b> <br /> Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
           criteria:
             'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
           double_count: ['All'],
@@ -4513,7 +4514,7 @@ const minorMath: Minor = {
         {
           required_credits: 4,
           description:
-            '** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
+            '** <b>ALTERNATIVE PATH:</b> <br /> A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
           criteria:
             'EN Applied Mathematics & Statistics[D]^AND^(300[L]^OR^400[L]^OR^500[L])',
           double_count: ['All'],
@@ -4521,7 +4522,7 @@ const minorMath: Minor = {
         {
           required_credits: 8,
           description:
-            '** With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
+            '** <b>ALTERNATIVE PATH (cont.):</b> <br /> With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
           criteria:
             'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
           double_count: ['All'],

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -4489,8 +4489,7 @@ const minorMath: Minor = {
       min_credits_per_course: 4,
       description:
         'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
-      criteria:
-        'AS Mathematics[D]^AND^(200[L]^OR^300[L])',
+      criteria: 'AS Mathematics[D]^AND^(200[L]^OR^300[L])',
       double_count: [],
     },
     {

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -4490,7 +4490,7 @@ const minorMath: Minor = {
       description:
         'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
       criteria:
-        'AS Mathematics[D]^AND^(200[L]^OR^300[L])^NOT^AS.110.202[C]^NOT^AS.110.225[C]',
+        'AS Mathematics[D]^AND^(200[L]^OR^300[L])',
     },
     {
       name: '300-Level or Above Courses',
@@ -4508,6 +4508,7 @@ const minorMath: Minor = {
             'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
           criteria:
             'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 4,
@@ -4515,6 +4516,7 @@ const minorMath: Minor = {
             '** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
           criteria:
             'EN Applied Mathematics & Statistics[D]^AND^(300[L]^OR^400[L]^OR^500[L])',
+          double_count: ['All'],
         },
         {
           required_credits: 8,
@@ -4522,6 +4524,7 @@ const minorMath: Minor = {
             '** With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
           criteria:
             'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+          double_count: ['All'],
         },
       ],
     },

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3917,19 +3917,20 @@ const minorMath: Minor = {
       name: 'Calculus Courses',
       required_credits: 12,
       min_credits_per_course: 4,
-      description: 
-      'Students must take Calculus I, II, and III.',
-      criteria: 
-      'AS.110.106[C]^OR^AS.110.108[C]^OR^AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]',
+      description: 'Students must take Calculus I, II, and III.',
+      criteria:
+        'AS.110.106[C]^OR^AS.110.108[C]^OR^AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]',
       fine_requirements: [
         {
           required_credits: 4,
-          description: '<b>Calculus I</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering)',
+          description:
+            '<b>Calculus I</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering)',
           criteria: 'AS.110.106[C]^OR^AS.110.108[C]',
         },
         {
           required_credits: 4,
-          description: '<b>Calculus II</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering) or Honors Single Variable Calculus',
+          description:
+            '<b>Calculus II</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering) or Honors Single Variable Calculus',
           criteria: 'AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]',
         },
         {
@@ -3943,36 +3944,46 @@ const minorMath: Minor = {
       name: '200- or 300-Level Course',
       required_credits: 4,
       min_credits_per_course: 4,
-      description: 'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
-      criteria: 'AS Mathematics[D]^AND^(200[L]^OR^300[L])^NOT^AS.110.202[C]^NOT^AS.110.225[C]',
+      description:
+        'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
+      criteria:
+        'AS Mathematics[D]^AND^(200[L]^OR^300[L])^NOT^AS.110.202[C]^NOT^AS.110.225[C]',
     },
     {
       name: '300-Level or Above Courses',
       required_credits: 12,
       min_credits_per_course: 4,
-      description: 'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345). <br /> <br /> ** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. However, only a course from AMS can serve as a substitute.',
-      criteria: '(AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D])^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+      description:
+        'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345). <br /> <br /> ** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. However, only a course from AMS can serve as a substitute.',
+      criteria:
+        '(AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D])^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
       pathing: 2,
       fine_requirements: [
         {
           required_credits: 12,
-          description: 'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
-          criteria: 'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+          description:
+            'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
+          criteria:
+            'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
         },
         {
           required_credits: 4,
-          description: '** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
-          criteria: 'EN Applied Mathematics & Statistics[D]^AND^(300[L]^OR^400[L]^OR^500[L])',
+          description:
+            '** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
+          criteria:
+            'EN Applied Mathematics & Statistics[D]^AND^(300[L]^OR^400[L]^OR^500[L])',
         },
         {
           required_credits: 8,
-          description: '** With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
-          criteria: 'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+          description:
+            '** With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
+          criteria:
+            'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
         },
       ],
     },
-  ]
-}
+  ],
+};
 
 const no_degree: Major = {
   degree_name: "Undecided Degree/My degree isn't supported yet",

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3903,6 +3903,77 @@ const minorPhysics: Minor = {
   ],
 };
 
+// https://mathematics.jhu.edu/undergraduate/minor-in-mathematics/
+// https://e-catalogue.jhu.edu/arts-sciences/full-time-residential-programs/degree-programs/mathematics/mathematics-minor/
+const minorMath: Minor = {
+  degree_name: 'Minor Mathematics',
+  abbrev: 'Minor Math',
+  department: 'AS Mathematics',
+  total_degree_credit: 28,
+  url: 'https://e-catalogue.jhu.edu/arts-sciences/full-time-residential-programs/degree-programs/mathematics/mathematics-minor/',
+  wi_credit: 0,
+  distributions: [
+    {
+      name: 'Calculus Courses',
+      required_credits: 12,
+      min_credits_per_course: 4,
+      description: 
+      'Students must take Calculus I, II, and III.',
+      criteria: 
+      'AS.110.106[C]^OR^AS.110.108[C]^OR^AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]',
+      fine_requirements: [
+        {
+          required_credits: 4,
+          description: '<b>Calculus I</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering)',
+          criteria: 'AS.110.106[C]^OR^AS.110.108[C]',
+        },
+        {
+          required_credits: 4,
+          description: '<b>Calculus II</b> <br/>(Biology and Social Sciences) or (Physical Sciences & Engineering) or Honors Single Variable Calculus',
+          criteria: 'AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]',
+        },
+        {
+          required_credits: 4,
+          description: '<b>Calculus III</b>',
+          criteria: 'AS.110.202[C]',
+        },
+      ],
+    },
+    {
+      name: '200- or 300-Level Course',
+      required_credits: 4,
+      min_credits_per_course: 4,
+      description: 'Students must take one 200-level or above math course (excluding AS.110.202 Calculus III and the 2-credit 225).',
+      criteria: 'AS Mathematics[D]^AND^(200[L]^OR^300[L])^NOT^AS.110.202[C]^NOT^AS.110.225[C]',
+    },
+    {
+      name: '300-Level or Above Courses',
+      required_credits: 12,
+      min_credits_per_course: 4,
+      description: 'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345). <br /> <br /> ** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. However, only a course from AMS can serve as a substitute.',
+      criteria: '(AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D])^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+      pathing: 2,
+      fine_requirements: [
+        {
+          required_credits: 12,
+          description: 'Students must take three mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).**',
+          criteria: 'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+        },
+        {
+          required_credits: 4,
+          description: '** A course in the Department of Applied Mathematics and Statistics (AMS), at the corresponding level, may be substituted for one of the 300-level or above courses. ',
+          criteria: 'EN Applied Mathematics & Statistics[D]^AND^(300[L]^OR^400[L]^OR^500[L])',
+        },
+        {
+          required_credits: 8,
+          description: '** With an AMS course substitution, students must take two mathematics courses at the 300-level or above (excluding the 1-credit seminar 345).',
+          criteria: 'AS Mathematics[D]^AND^(300[L]^OR^400[L]^OR^500[L])^NOT^AS.110.345[C]',
+        },
+      ],
+    },
+  ]
+}
+
 const no_degree: Major = {
   degree_name: "Undecided Degree/My degree isn't supported yet",
   distributions: [],
@@ -3948,6 +4019,7 @@ export const allMajors: Major[] = [
   baEcon,
   minorEcon,
   minorPhysics,
+  minorMath,
   // baPsych,
   // baMolCell,
   // bsNeuro,


### PR DESCRIPTION
### **UI Updates:**
<img width="365" alt="image" src="https://user-images.githubusercontent.com/95264539/180679278-4c7e9a69-b821-4808-a378-6b6226bdd0e4.png">

I created three distributions:
1. Calculus Courses (You have to take Calculus I, II, and III with some alternative options...)
2. 200-Level or 300-Level (self-explanatory, 1 course for this)
3. 300-Level or Above (3 math courses; used updated pathing for this to satisfy an alternate route: 1 AMS course and 2 math courses)