### PR TITLE
fix: double_count default is no double count 

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -199,25 +199,27 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
     // If double_count is string[], the specified distributions / fine requirements are 'whitelisted'
     // When a course satisfies a distribution, double_count takes the value of distribution.double_count
     if (!courseObj) return;
-    let distDoubleCount: string[] | undefined = undefined; // initial value
+    let distDoubleCount: string[] | undefined = ['All']; // double count by defualt 
     reqs.forEach((reqGroup, i) => {
       let req = reqGroup[1][0]; // general distribution
       if (
-        (!distDoubleCount || distDoubleCount.includes(req.name)) &&
+        distDoubleCount && 
+        (distDoubleCount.includes(req.name) || distDoubleCount.includes('All')) &&
         (req.fulfilled_credits < req.required_credits ||
           (req.required_credits === 0 && req.fulfilled_credits === 0)) &&
         checkRequirementSatisfied(req, courseObj)
       ) {
         reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
         distDoubleCount = req.double_count; // set double_count, if any
-        let fineDoubleCount: string[] | undefined = undefined;
+        let fineDoubleCount: string[] | undefined = ['All'];
         reqGroup[1].forEach((req: requirements, j: number) => {
           // fine reqs
           if (j !== 0) {
             // 0 is the general distribution, not fine req
             let fineReq = reqGroup[1][j];
             if (
-              (!fineDoubleCount || fineDoubleCount.includes(fineReq.name)) &&
+              fineDoubleCount && 
+              (fineDoubleCount.includes(fineReq.name) || fineDoubleCount.includes('All')) &&
               (fineReq.fulfilled_credits < fineReq.required_credits ||
                 (fineReq.required_credits === 0 &&
                   fineReq.fulfilled_credits === 0)) &&

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -195,14 +195,14 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
 
   const updateReqs = (reqs: [string, requirements[]][], courseObj) => {
     // double_count check:
-    // If double_count is undefined, the course may only count for one distribution 
+    // If double_count is undefined, the course may only count for one distribution
     // If double_count is string[], the specified distributions / fine requirements are 'whitelisted'
-    // If double_count is ['All'], the course may double count freely 
+    // If double_count is ['All'], the course may double count freely
     if (!courseObj) return;
     let distDoubleCount: string[] | undefined = ['All'];
     reqs.forEach((reqGroup, i) => {
       let req = reqGroup[1][0]; // general distribution
-      // if course satisfies distribution: 
+      // if course satisfies distribution:
       if (
         distDoubleCount &&
         (distDoubleCount.includes(req.name) ||
@@ -213,7 +213,7 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       ) {
         reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
         distDoubleCount = req.double_count; // set double_count, if any
-        // for each fine req, see if course satisfies fine requirements 
+        // for each fine req, see if course satisfies fine requirements
         processFines(reqs, courseObj, i);
       }
     });
@@ -226,16 +226,17 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
   };
 
   const processFines = (
-    reqs: [string, requirements[]][], 
-    courseObj, 
-    i: number
+    reqs: [string, requirements[]][],
+    courseObj,
+    i: number,
   ) => {
     let fineDoubleCount: string[] | undefined = ['All'];
     // for each fine req
     reqs[i][1].forEach((req: requirements, j: number) => {
-      if (j !== 0) {    // skip general distribution, not fine req
+      if (j !== 0) {
+        // skip general distribution, not fine req
         let fineReq = reqs[i][1][j];
-        // if course satisfies fine requirement 
+        // if course satisfies fine requirement
         if (
           fineDoubleCount &&
           (fineDoubleCount.includes(fineReq.name) ||
@@ -245,13 +246,13 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
               fineReq.fulfilled_credits === 0)) &&
           checkRequirementSatisfied(fineReq, courseObj)
         ) {
-          // update fine requirements 
+          // update fine requirements
           reqs[i][1][j].fulfilled_credits += parseInt(courseObj.credits);
           fineDoubleCount = fineReq.double_count;
         }
       }
     });
-  }
+  };
 
   const processReq = (
     req: requirements,

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -199,12 +199,13 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
     // If double_count is string[], the specified distributions / fine requirements are 'whitelisted'
     // When a course satisfies a distribution, double_count takes the value of distribution.double_count
     if (!courseObj) return;
-    let distDoubleCount: string[] | undefined = ['All']; // double count by defualt 
+    let distDoubleCount: string[] | undefined = ['All']; // double count by defualt
     reqs.forEach((reqGroup, i) => {
       let req = reqGroup[1][0]; // general distribution
       if (
-        distDoubleCount && 
-        (distDoubleCount.includes(req.name) || distDoubleCount.includes('All')) &&
+        distDoubleCount &&
+        (distDoubleCount.includes(req.name) ||
+          distDoubleCount.includes('All')) &&
         (req.fulfilled_credits < req.required_credits ||
           (req.required_credits === 0 && req.fulfilled_credits === 0)) &&
         checkRequirementSatisfied(req, courseObj)
@@ -218,8 +219,9 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
             // 0 is the general distribution, not fine req
             let fineReq = reqGroup[1][j];
             if (
-              fineDoubleCount && 
-              (fineDoubleCount.includes(fineReq.name) || fineDoubleCount.includes('All')) &&
+              fineDoubleCount &&
+              (fineDoubleCount.includes(fineReq.name) ||
+                fineDoubleCount.includes('All')) &&
               (fineReq.fulfilled_credits < fineReq.required_credits ||
                 (fineReq.required_credits === 0 &&
                   fineReq.fulfilled_credits === 0)) &&

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -195,13 +195,14 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
 
   const updateReqs = (reqs: [string, requirements[]][], courseObj) => {
     // double_count check:
-    // If double_count is undefined, the course may double count for any number of distributions
+    // If double_count is undefined, the course may only count for one distribution 
     // If double_count is string[], the specified distributions / fine requirements are 'whitelisted'
-    // When a course satisfies a distribution, double_count takes the value of distribution.double_count
+    // If double_count is ['All'], the course may double count freely 
     if (!courseObj) return;
-    let distDoubleCount: string[] | undefined = ['All']; // double count by defualt
+    let distDoubleCount: string[] | undefined = ['All'];
     reqs.forEach((reqGroup, i) => {
       let req = reqGroup[1][0]; // general distribution
+      // if course satisfies distribution: 
       if (
         distDoubleCount &&
         (distDoubleCount.includes(req.name) ||
@@ -212,26 +213,8 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       ) {
         reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
         distDoubleCount = req.double_count; // set double_count, if any
-        let fineDoubleCount: string[] | undefined = ['All'];
-        reqGroup[1].forEach((req: requirements, j: number) => {
-          // fine reqs
-          if (j !== 0) {
-            // 0 is the general distribution, not fine req
-            let fineReq = reqGroup[1][j];
-            if (
-              fineDoubleCount &&
-              (fineDoubleCount.includes(fineReq.name) ||
-                fineDoubleCount.includes('All')) &&
-              (fineReq.fulfilled_credits < fineReq.required_credits ||
-                (fineReq.required_credits === 0 &&
-                  fineReq.fulfilled_credits === 0)) &&
-              checkRequirementSatisfied(fineReq, courseObj)
-            ) {
-              reqs[i][1][j].fulfilled_credits += parseInt(courseObj.credits);
-              fineDoubleCount = fineReq.double_count;
-            }
-          }
-        });
+        // for each fine req, see if course satisfies fine requirements 
+        processFines(reqs, courseObj, i);
       }
     });
     // Pathing check
@@ -241,6 +224,34 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       }),
     );
   };
+
+  const processFines = (
+    reqs: [string, requirements[]][], 
+    courseObj, 
+    i: number
+  ) => {
+    let fineDoubleCount: string[] | undefined = ['All'];
+    // for each fine req
+    reqs[i][1].forEach((req: requirements, j: number) => {
+      if (j !== 0) {    // skip general distribution, not fine req
+        let fineReq = reqs[i][1][j];
+        // if course satisfies fine requirement 
+        if (
+          fineDoubleCount &&
+          (fineDoubleCount.includes(fineReq.name) ||
+            fineDoubleCount.includes('All')) &&
+          (fineReq.fulfilled_credits < fineReq.required_credits ||
+            (fineReq.required_credits === 0 &&
+              fineReq.fulfilled_credits === 0)) &&
+          checkRequirementSatisfied(fineReq, courseObj)
+        ) {
+          // update fine requirements 
+          reqs[i][1][j].fulfilled_credits += parseInt(courseObj.credits);
+          fineDoubleCount = fineReq.double_count;
+        }
+      }
+    });
+  }
 
   const processReq = (
     req: requirements,

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -126,26 +126,31 @@ const baCogSci: Major = {
           description: '<b>Cognitive Psychology/Cognitive Neuropsychology</b>',
           required_credits: 3,
           criteria: 'COGS-COGPSY[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Linguistics</b>',
           required_credits: 3,
           criteria: 'COGS-LING[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Computational Approaches to Cognition</b>',
           required_credits: 3,
           criteria: 'COGS-COMPCG[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Philosophy of Mind</b>',
           required_credits: 3,
           criteria: 'COGS-PHLMND[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Neuroscience</b>',
           required_credits: 3,
           criteria: 'COGS-NEURO[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -173,6 +178,7 @@ const baCogSci: Major = {
             'At least 2 courses must be at the 300 level or above.',
           required_credits: 12,
           criteria: 'COGS-COGPSY[T]',
+          double_count: ['All'],
         },
         {
           description:
@@ -180,6 +186,7 @@ const baCogSci: Major = {
             'At least 2 courses must be at the 300 level or above.',
           required_credits: 12,
           criteria: 'COGS-LING[T]',
+          double_count: ['All'],
         },
         {
           description:
@@ -187,6 +194,7 @@ const baCogSci: Major = {
             'At least 2 courses must be at the 300 level or above.',
           required_credits: 12,
           criteria: 'COGS-COMPCG[T]',
+          double_count: ['All'],
         },
         {
           description:
@@ -194,6 +202,7 @@ const baCogSci: Major = {
             'At least 2 courses must be at the 300 level or above.',
           required_credits: 12,
           criteria: 'COGS-PHLMND[T]',
+          double_count: ['All'],
         },
         {
           description:
@@ -201,6 +210,7 @@ const baCogSci: Major = {
             'At least 2 courses must be at the 300 level or above.',
           required_credits: 12,
           criteria: 'COGS-NEURO[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -231,6 +241,7 @@ const baCogSci: Major = {
         'AS.110.106[C]^OR^AS.110.108[C]^OR^AS.110.107[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^' +
         'AS.110.201[C]^OR^AS.110.212[C]^OR^EN.553.291[C]^OR^AS.150.118[C]^OR^AS.150.420[C]^OR^AS.050.370[C]^OR^' +
         'AS.050.371[C]^OR^AS.050.372[C]^OR^EN.553.171[C]^OR^AS.200.200[C]^OR^AS.200.201[C]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -321,6 +332,7 @@ const baCogSci: Major = {
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
         'Writing-intensive courses taken to satisfy major, minor, or distribution requirements may also count toward the writing requirement.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
     },
   ],
 };
@@ -610,6 +622,7 @@ const baEcon: Major = {
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
         'Writing-intensive courses taken to satisfy major, minor, or distribution requirements may also count toward the writing requirement.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
     },
   ],
 };
@@ -868,7 +881,6 @@ const bsBME: Major = {
       description:
         'Students are required to take at least one semester of programming from a select set of gateway computing courses.',
       criteria: 'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]',
-      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -901,36 +913,43 @@ const bsBME: Major = {
           description: '<b>Biomedical Data Science</b>',
           required_credits: 21,
           criteria: 'BMED-BDS[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Computational Medicine</b>',
           required_credits: 21,
           criteria: 'BMED-CM[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Genomics and Systems Biology</b>',
           required_credits: 21,
           criteria: 'BMED-GSB[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Imaging and Medical Devices</b>',
           required_credits: 21,
           criteria: 'BMED-IMD[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Imunoengineering</b>',
           required_credits: 21,
           criteria: 'BMED-IMMU[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Neuroengineering</b>',
           required_credits: 21,
           criteria: 'BMED-NE[T]',
+          double_count: ['All'],
         },
         {
           description: '<b>Translational Cell and Tissue Engineering</b>',
           required_credits: 21,
           criteria: 'BMED-TCTE[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -1040,7 +1059,6 @@ const bsBME: Major = {
       min_credits_per_course: 1,
       description: 'Select 9 credits from any area.',
       criteria: 'H[A]^OR^S[A]^OR^Q[A]^OR^N[A]^OR^E[A]',
-      double_count: ['N/A'],
     },
     {
       name: 'Humanities and Social Sciences',
@@ -1072,12 +1090,7 @@ const bsBME: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
       criteria: 'Written Intensive[W]',
-      double_count: [
-        'Biomedical Core',
-        'Focus Area',
-        'Design',
-        'Humanities and Social Sciences',
-      ],
+      double_count: ['All'],
     },
   ],
 };
@@ -1417,6 +1430,7 @@ const bsCBE: Major = {
       criteria:
         'EN.500.113[C]^OR^EN.540.101[C]^OR^EN.540.202[C]^OR^EN.540.203[C]^OR^EN.540.301[C]^OR^EN.540.303[C]^OR^EN.540.304[C]^OR^' +
         'EN.540.306[C]^OR^EN.540.315[C]^OR^EN.540.409[C]^OR^EN.540.490[C]^OR^EN.540.311[C]^OR^EN.540.313[C]',
+      double_count: ['Liberal Arts', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -1499,7 +1513,7 @@ const bsCBE: Major = {
       min_credits_per_course: 3,
       description:
         'Take one of the following course options for Product Design.',
-      criteria: '',
+      criteria: 'EN.540.314[C]^OR^EN.540.309[C]^OR^EN.540.310[C]^OR^EN.500.308[C]^OR^EN.500.309[C]',
       pathing: 1,
       fine_requirements: [
         {
@@ -1565,6 +1579,7 @@ const bsCBE: Major = {
       criteria:
         'AS.171.101[C]^OR^AS.171.107[C]^OR^AS.171.102[C]^OR^AS.171.108[C]^OR^AS.173.111[C]^OR^AS.173.112[C]' +
         '^OR^AS.030.101[C]^OR^AS.030.102[C]^OR^AS.030.105[C]^OR^AS.030.106[C]',
+      double_count: ['Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -1638,6 +1653,7 @@ const bsCBE: Major = {
         'The student must take elective courses to meet the remainder of the following requirements: <br /> 48 credits of Engineering (E designation) <br />' +
         '16 credits of Mathematics (must be from 110 or 553) <br /> 13 credits Advanced Chemistry and Biology <br /> 18 H/S credits (must be six courses that are at least 3 credits each)',
       criteria: '',
+      double_count: ['Writing Intensive'],
       fine_requirements: [
         {
           description: '<b>Engineering Credits</b>',
@@ -1670,6 +1686,7 @@ const bsCBE: Major = {
         'Select courses to form a coherent program, relevant to the student’s goals. One course in which ethical and social ' +
         'issues related to technology or medicine is recommended.',
       criteria: 'H[A]^OR^S[A]',
+      double_count: ['Core ChemBE', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -1687,6 +1704,7 @@ const bsCBE: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'], 
     },
   ],
 };
@@ -1725,24 +1743,28 @@ const baIS: Major = {
           description:
             '<b>One INST-IR course</b> <br /> One course in international relations (IR)',
           criteria: 'INST-IR[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description:
             '<b>Two INST-CP courses</b> <br /> Two courses in comparative politics (CP)',
           criteria: 'INST-CP[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 3,
           description:
             '<b>One INST-AP course</b> <br /> One course in American politics (AP)',
           criteria: 'INST-AP[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 3,
           description:
             '<b>One INST-PT course</b> <br /> One course in political theory (PT)',
           criteria: 'INST-PT[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 3,
@@ -1753,6 +1775,7 @@ const baIS: Major = {
             'students who entered fall 2019 and earlier only.',
           criteria:
             'AS.070.295[C]^OR^AS.190.108[C]^OR^AS.190.111[C]^OR^(AS.230.150[C]^AND^Fall 2019[Y])',
+          double_count: ['All'],
         },
       ],
     },
@@ -1871,12 +1894,14 @@ const baIS: Major = {
           description:
             '<b>Introductory History Course</b> One introductory course at the 100-level in the JHU History Department (e.g., AS.100.1xx)',
           criteria: 'AS History[D]^AND^100[L]',
+          double_count: ['All'],
         },
         {
           required_credits: 12,
           description:
             '<b>Four INST-GLOBAL courses</b> <br /> Four courses designated INST-GLOBAL in the course description',
           criteria: 'INST-GLOBAL[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -1943,6 +1968,7 @@ const baIS: Major = {
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
         'Writing-intensive courses taken to satisfy major, minor, or distribution requirements may also count toward the writing requirement.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
     },
   ],
 };
@@ -1966,6 +1992,7 @@ const bsAMS: Major = {
         'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]^OR^AS.110.211[C]^OR^AS.110.201[C]^OR^AS.110.212[C]^OR^EN.553.291[C]^OR^' +
         'AS.110.302[C]^OR^EN.553.391[C]^OR^EN.540.468[C]^OR^EN.553.385[C]^OR^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.553.371[C]^OR^EN.553.471[C]^OR^EN.553.472[C]^OR^' +
         'EN.553.420[C]^OR^EN.553.430[C]^OR^EN.553.431[C]^OR^EN.553.361[C]',
+      double_count: ['Quantitative Studies'],
       fine_requirements: [
         {
           description:
@@ -2045,6 +2072,7 @@ const bsAMS: Major = {
       criteria:
         'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]^OR^AS.250.205[C]^OR^EN.553.281[C]^OR^(EN.580.242[C]^AND^EN.580.244[C])^OR^' +
         'EN.601.220[C]^OR^AS.250.205[C]',
+      double_count: ['Quantitative Studies'],
     },
     {
       name: 'Area of Focus',
@@ -2061,6 +2089,7 @@ const bsAMS: Major = {
         'AS.110.401[C]^OR^EN.553.371[C]^OR^EN.553.471[C]^OR^EN.553.472[C]^OR^' +
         'EN.553.428[C]^OR^EN.553.441[C]^OR^EN.553.442[C]^OR^EN.553.444[C]^OR^EN.553.445[C]^OR^EN.553.447[C]^OR^EN.553.448[C]^OR^EN.553.449[C]^OR^EN.553.488[C]^OR^' +
         'EN.553.481[C]^OR^EN.553.493[C]',
+      double_count: ['All'],
       fine_requirements: [
         {
           required_credits: 6,
@@ -2117,6 +2146,7 @@ const bsAMS: Major = {
         'AS.110.445[C]^OR^EN.553.400[C]^OR^EN.553.413[C]^OR^EN.553.432[C]^OR^EN.553.433[C]^OR^EN.553.436[C]' +
         '^OR^EN.553.450[C]^OR^EN.553.463[C]^OR^EN.553.467[C]^OR^EN.553.481[C]^OR^EN.553.488[C]^OR^EN.553.493[C]' +
         '^OR^EN.553.494[C]^OR^EN.601.433[C]^OR^EN.601.475[C]^OR^EN.601.482[C]',
+      double_count: ['All'],
     },
     {
       name: 'Natural Sciences',
@@ -2126,6 +2156,7 @@ const bsAMS: Major = {
         'Courses coded Natural Sciences. Laboratory courses that accompany Natural Science courses may' +
         ' be used in reaching this total. (Courses used to meet the requirements above may be counted toward this total.)',
       criteria: 'N[A]',
+      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
     },
     {
       name: 'Quantitative Studies',
@@ -2135,6 +2166,7 @@ const bsAMS: Major = {
         'Courses coded Quantitative Studies totaling 40 credits of which at least 18 credits must be in courses ' +
         'numbered 300 or higher. (Courses used to meet the requirements above may be counted toward this total.)',
       criteria: 'Q[A]',
+      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
       fine_requirements: [
         {
           description:
@@ -2155,6 +2187,7 @@ const bsAMS: Major = {
         'they don’t carry an ‘H’ or ‘S’ designator.',
       criteria:
         'AS Center for Language Education[D]^OR^AS Modern Languages and Literatures[D]^OR^H[A]^OR^S[A]',
+      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
     },
     {
       name: 'Writing Intensive',
@@ -2164,6 +2197,7 @@ const bsAMS: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
@@ -2208,7 +2242,6 @@ const bsCS_Old: Major = {
             'EN.660.400 Practical Ethics for Future Leaders',
           required_credits: 1,
           criteria: 'EN.601.104[C]^OR^EN.660.400[C]',
-          double_count: ['N/A'],
         },
         {
           description:
@@ -2250,7 +2283,6 @@ const bsCS_Old: Major = {
             '<b>Intro Algorithms</b> <br /> EN.601.433 Intro Algorithms',
           required_credits: 3,
           criteria: 'EN.601.433[C]',
-          double_count: ['N/A'],
         },
         {
           description:
@@ -2429,13 +2461,13 @@ const bsCS_New: Major = {
         'major degree requirement</a> section on the department website.',
       criteria:
         'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
             '<b>Computer Ethics(601.104).</b><p>Practical Ethics for Future Leaders (660.400/406) may be used as a substitute for the computer ethics requirement for the BS program, but does not count towards the CS total credits at all.</p>',
           required_credits: 1,
           criteria: 'EN.600.104[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
-          double_count: ['N/A'],
         },
         {
           description:
@@ -2446,7 +2478,6 @@ const bsCS_New: Major = {
           criteria:
             'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]^OR^EN.601.220[C]^OR^EN.601.226[C]' +
             '^OR^EN.601.229[C]^OR^EN.601.230[C]^OR^EN.601.433[C]^OR^EN.601.231',
-          double_count: ['N/A'],
         },
         {
           description:
@@ -2500,7 +2531,7 @@ const bsCS_New: Major = {
         'may not count towards these math requirements. Other than Calculus I and II, all the ' +
         'remaining courses must be 200-level or above.',
       criteria: 'AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D]',
-      exception: 'EN.553.171[C]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
@@ -2527,6 +2558,7 @@ const bsCS_New: Major = {
         'taking any of the 553.3xx combined Probability & Statistics courses. Probability and Statistics:</p><p>Two paths:</p>',
       criteria:
         'EN.553.211[C]^OR^EN.553.310[C]^OR^EN.553.311[C]^OR^EN.553.420[C]^OR^EN.553.430[C]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -2551,6 +2583,7 @@ const bsCS_New: Major = {
         'Students must take two semesters of core science courses (any combination of Physics, ' +
         'Chemistry, Biology), with their associated labs. AP credit is an acceptable substitute for these courses and labs.',
       criteria: 'N[A]',
+      double_count: ['All'],
     },
     {
       name: 'Liberal Arts',
@@ -2563,6 +2596,7 @@ const bsCS_New: Major = {
         'they don’t carry an ‘H’ or ‘S’ designator.',
       criteria:
         'AS Center for Language Education[D]^OR^AS Modern Languages and Literatures[D]^OR^H[A]^OR^S[A]',
+      double_count: ['All'],
     },
     {
       name: 'Writing Intensive',
@@ -2572,12 +2606,12 @@ const bsCS_New: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
             '<b>Writing-focused WI</b><p>At least one course must be explicitly focused on writing skills in English (eg, courses in professional, ' +
             'fiction or expository writing). These courses may overlap with other requirements.</p><p>Any of the courses below would be satisfactory:</p><p>AS.060.100</p><p>AS.060.113</p><p>AS.060.114</p><p>AS.180.248</p><p>AS.220.105</p><p>AS.220.106</p><p>AS.220.108</p><p>AS.290.303</p><p>AS.360.133</p><p>EN.661.110</p><p>EN.661.111</p><p>EN.661.250</p><p>EN.661.251</p><p>EN.661.315</p>',
-
           required_credits: 3,
           criteria:
             'AS.060.100[C]^OR^AS.060.113[C]^OR^AS.060.114[C]^OR^AS.180.248[C]^OR^AS.220.105[C]^OR^AS.220.106[C]^OR^AS.220.108[C]^OR^AS.290.303[C]^OR^AS.360.133[C]^OR^EN.661.110[C]^OR^EN.661.111[C]^OR^EN.661.250[C]^OR^EN.661.251[C]^OR^EN.661.315[C]',
@@ -2605,6 +2639,7 @@ const baCS_New: Major = {
         'major degree requirement</a> section on the department website.',
       criteria:
         'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
@@ -2625,7 +2660,6 @@ const baCS_New: Major = {
         {
           description:
             '<b>Upper Level Undergraduate: </b><p>12 upper level CS credits in addition to the required Algorithms course</p>',
-
           required_credits: 12,
           criteria:
             'EN Computer Science[D]^AND^Upper Level Undergraduate[L]^NOT^EN.601.433[C]^NOT^EN.601.633[C]',
@@ -2641,6 +2675,7 @@ const baCS_New: Major = {
         'campus: Mathematics or Applied Math and Statistics. However, 553.171 Discrete Mathematics ' +
         'may not count towards these math requirements. At least one course must be 200-level or above',
       criteria: 'AS Mathematics[D]^OR^EN Applied Mathematics & Statistics[D]',
+      double_count: ['All'],
       exception: 'EN.553.171[C]',
       fine_requirements: [
         {
@@ -2660,6 +2695,7 @@ const baCS_New: Major = {
         'Students must take two semesters of core science courses (any combination of Physics, ' +
         'Chemistry, Biology), with their associated labs. AP credit is an acceptable substitute for these courses and labs.',
       criteria: 'N[A]',
+      double_count: ['All'],
     },
     {
       name: 'Liberal Arts',
@@ -2672,6 +2708,7 @@ const baCS_New: Major = {
         'in addition to the six H/S required courses. Students must still have at least six (>=3)-credit courses to fulfill the H/S requirement.',
       criteria:
         'AS Center for Language Education[D]^OR^AS Modern Languages and Literatures[D]^OR^H[A]^OR^S[A]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description: '<b>300-level</b><p>Two Courses at 300 Level</p>',
@@ -2695,12 +2732,12 @@ const baCS_New: Major = {
         'Students are required to fulfill the university’s requirement of four writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses. ',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
       fine_requirements: [
         {
           description:
             '<b>Writing-focused WI</b><p>At least one course must be explicitly focused on writing skills in English (eg, courses in professional, ' +
             'fiction or expository writing). These courses may overlap with other requirements.</p><p>Any of the courses below would be satisfactory:</p><p>AS.060.100</p><p>AS.060.113</p><p>AS.060.114</p><p>AS.180.248</p><p>AS.220.105</p><p>AS.220.106</p><p>AS.220.108</p><p>AS.290.303</p><p>AS.360.133</p><p>EN.661.110</p><p>EN.661.111</p><p>EN.661.250</p><p>EN.661.251</p><p>EN.661.315</p>',
-
           required_credits: 3,
           criteria:
             'AS.060.100[C]^OR^AS.060.113[C]^OR^AS.060.114[C]^OR^AS.180.248[C]^OR^AS.220.105[C]^OR^AS.220.106[C]^OR^AS.220.108[C]^OR^AS.290.303[C]^OR^AS.360.133[C]^OR^EN.661.110[C]^OR^EN.661.111[C]^OR^EN.661.250[C]^OR^EN.661.251[C]^OR^EN.661.315[C]',
@@ -2727,7 +2764,6 @@ const CS_Minor_New: Minor = {
         "For more information please visit the <a href=' https://www.cs.jhu.edu/undergraduate-studies/academics/cs-minor/'>" +
         'minor degree requirement</a> section on the department website.',
       criteria: 'Gateway Computing[N]^OR^EN.601.220[C]^OR^EN.601.226[C]',
-      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -2756,32 +2792,36 @@ const CS_Minor_New: Minor = {
       description:
         '<b>Upper Level Undergraduate: </b><p>9 upper level CS credits that form a cohesive program of study and <b>must be approved by the computer science minor advisor</b>. One way is to choose all three courses within one or two area tag classifications (CSCI-APPL, CSCI-SOFT, CSCI-THRY, CSCI-RSNG, CSCI-SYST)</p>',
       criteria: 'EN Computer Science[D]^AND^Upper Level Undergraduate[L]',
-      double_count: ['N/A'],
       fine_requirements: [
         {
           required_credits: 6,
           description: '<b>Software</b>',
           criteria: 'CSCI-SOFT[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Applications</b>',
           criteria: 'CSCI-APPL[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Systems</b>',
           criteria: 'CSCI-SYST[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Reasoning</b>',
           criteria: 'CSCI-RSNG[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Theory</b>',
           criteria: 'CSCI-THRY[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -2792,16 +2832,7 @@ const CS_Minor_New: Minor = {
       description:
         '<b>Elective Course. Any CS course >= 601.200 that is at least three credits</b>',
       criteria:
-        'EN.601.2[C]^OR^EN.600.2[C]^OR^EN.601.3[C]^OR^EN.600.3[C]^OR^EN.601.4[C]^OR^EN.600.4[C]^OR^EN.601.5[C]^OR^EN.600.5[C]^OR^EN.601.6[C]^OR^EN.600.6[C]^OR^EN.601.7[C]^OR^EN.600.7[C]',
-      double_count: ['N/A'],
-      fine_requirements: [
-        {
-          description:
-            '<b>Discrete Math:</b> Although not explicitly required, EN.553.171 Discrete Math is also strongly recommended for CS minors but does not count towards the minor requirements',
-          required_credits: 0,
-          criteria: 'EN.553.171[C]',
-        },
-      ],
+        'EN Computer Science[D]^AND^(200[L]^OR^Upper Level Undergraduate[L])',
     },
   ],
 };
@@ -2824,7 +2855,6 @@ const CS_Minor_Old: Minor = {
         'minor degree requirement</a> section on the department website.',
       criteria:
         'Gateway Computing[N]^OR^EN.601.220[C]^OR^EN.601.226[C]^EN.600.233[C]^OR^EN.601.229[C]^OR^EN.600.271[C]^OR^EN.601.231[C]',
-      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -2857,7 +2887,6 @@ const CS_Minor_Old: Minor = {
       required_credits: 9,
       min_credits_per_course: 3,
       pathing: 1,
-      double_count: ['N/A'],
       description:
         '<b>Upper Level Undergraduate: </b><p>9 upper level CS credits that form a cohesive program of study and <b>must be approved by the computer science minor advisor</b>. One way is to choose all three courses within one or two area tag classifications (CSCI-APPL, CSCI-SOFT, CSCI-THRY, CSCI-RSNG, CSCI-SYST)</p>',
       criteria: 'EN Computer Science[D]^AND^Upper Level Undergraduate[L]',
@@ -2866,26 +2895,31 @@ const CS_Minor_Old: Minor = {
           required_credits: 6,
           description: '<b>Software</b>',
           criteria: 'CSCI-SOFT[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Applications</b>',
           criteria: 'CSCI-APPL[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Systems</b>',
           criteria: 'CSCI-SYST[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Reasoning</b>',
           criteria: 'CSCI-RSNG[T]',
+          double_count: ['All'],
         },
         {
           required_credits: 6,
           description: '<b>Theory</b>',
           criteria: 'CSCI-THRY[T]',
+          double_count: ['All'],
         },
       ],
     },
@@ -3210,6 +3244,7 @@ const bsMolCell: Major = {
         'All students earning a degree from the School of Arts and Sciences must complete at least 12 credits in writing-intensive courses. ' +
         'Writing-intensive courses taken to satisfy major, minor, or distribution requirements may also count toward the writing requirement.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
     },
     {
       name: 'Honors',
@@ -3250,7 +3285,6 @@ const bsMechE: Major = {
         'or the Applied Mathematics and Statistics department in the Whiting School of Engineering.',
       criteria:
         'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]^OR^EN.553.291[C]^OR^AS.110.201[C]^OR^AS.110.212[C]^OR^AS.110.302[C]',
-      double_count: ['N/A'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3264,6 +3298,7 @@ const bsMechE: Major = {
           required_credits: 16,
           criteria:
             'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]^OR^EN.553.291[C]',
+          double_count: ['All'],
         },
         {
           description:
@@ -3277,6 +3312,7 @@ const bsMechE: Major = {
           required_credits: 20,
           criteria:
             'AS.110.108[C]^OR^AS.110.109[C]^OR^AS.110.113[C]^OR^AS.110.202[C]^OR^AS.110.201[C]^OR^AS.110.212[C]^OR^AS.110.302[C]',
+          double_count: ['All'],
         },
       ],
     },
@@ -3290,7 +3326,6 @@ const bsMechE: Major = {
         'EN.553.311 Probability and Statistics for the Biological Sciences and Engineering <br />' +
         'EN.560.348 Probability and Statistics for Civil Engineering',
       criteria: 'EN.553.310[C]^OR^EN.553.311[C]^OR^EN.560.348[C]',
-      double_count: ['N/A'],
     },
     {
       name: 'Science',
@@ -3300,7 +3335,6 @@ const bsMechE: Major = {
         'The student must complete all the required science courses.',
       criteria:
         'AS.030.101[C]^OR^EN.171.101[C]^OR^AS.173.111[C]^OR^AS.171.102[C]^OR^AS.173.112[C]',
-      double_count: ['N/A'],
       fine_requirements: [
         {
           description:
@@ -3579,6 +3613,7 @@ const bsMechE: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
       criteria: 'Written Intensive[W]',
+      double_count: ['All'],
     },
   ],
 };
@@ -3601,6 +3636,7 @@ const minorAMS_Old: Minor = {
         '<br /> <em>**Note:</em> Within the entire minor, students may count only two of these three courses/course combinations: EN.553.310/EN.553.311; EN.553.420/620; EN.553.430/630.',
       criteria:
         'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3609,6 +3645,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3616,6 +3653,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3623,6 +3661,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3630,6 +3669,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3637,6 +3677,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3644,6 +3685,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3651,6 +3693,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3658,6 +3701,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3665,6 +3709,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3672,6 +3717,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3679,6 +3725,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3686,6 +3733,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
       ],
     },
@@ -3696,6 +3744,7 @@ const minorAMS_Old: Minor = {
       description:
         'Among the courses comprising the 18 Q credits, there must be at least four courses in the Department of Applied Mathematics and Statistics (each of these must be a 3- or 4-credit course).',
       criteria: 'Q[A]^AND^EN Applied Mathematics & Statistics[D]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3704,6 +3753,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3711,6 +3761,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3718,6 +3769,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3725,6 +3777,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3732,6 +3785,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3739,6 +3793,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3746,6 +3801,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3753,6 +3809,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3760,6 +3817,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3767,6 +3825,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3774,6 +3833,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3781,6 +3841,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
       ],
     },
@@ -3793,6 +3854,7 @@ const minorAMS_Old: Minor = {
         'of which at least two must be in the Department of Applied Mathematics and Statistics**.<br />' +
         '</br /> **A student may count the combination of (AS.110.201 Linear Algebra or AS.110.212 Honors Linear Algebra) AND AS.110.302 Differential Equations and Applications in place of ONE of the required 300-level courses within the AMS Department',
       criteria: 'Q[A]^AND^(300[L]^OR^400[L])',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3801,6 +3863,7 @@ const minorAMS_Old: Minor = {
             '<b>AMS Courses:</b> <br />At least two upper-level courses must be in the Department of Applied Mathematics and Statistics.**',
           criteria:
             '(300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D]',
+            double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -3808,6 +3871,7 @@ const minorAMS_Old: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.201 Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.201[C]^OR^AS.110.302[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -3815,6 +3879,7 @@ const minorAMS_Old: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.212 Honors Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.212[C]^OR^AS.110.302[C]',
+            double_count: ['All'],
         },
       ],
     },
@@ -3827,6 +3892,7 @@ const minorAMS_Old: Minor = {
         'an approved semester course in scientific computing, chosen from 171.426, 250.205, 500.200, 510.202, 530.371, 540.305, 553.281, 553.383, 553.385, 553.386, 553.388, 553.400, 553.413, 553.433, 553.436, 553.443, 553.450, 553.488, 553.489, 553.493, 560.220, 570.210, 580.200, 580.223, 580.242, 580.244, 601.433, 601.475, 601.482 or one of the courses approved to meet the AMS Master’s/PhD Computing Requirement.',
       criteria:
         'AS.171.426[C]^OR^AS.250.205[C]^OR^EN.500.200[C]^OR^EN.510.202[C]^OR^EN.530.371[C]^OR^EN.540.305[C]^OR^EN.553.281[C]^OR^EN.553.383[C]^OR^EN.553.385[C]^OR^EN.553.386[C]^OR^EN.553.388[C]^OR^EN.553.400[C]^OR^EN.553.413[C]^OR^EN.553.433[C]^OR^EN.553.436[C]^OR^EN.553.443[C]^OR^EN.553.450[C]^OR^EN.553.488[C]^OR^EN.553.489[C]^OR^EN.553.493[C]^OR^EN.560.220[C]^OR^EN.570.210[C]^OR^EN.580.200[C]^OR^EN.580.223[C]^OR^EN.580.242[C]^OR^EN.580.244[C]^OR^EN.601.433[C]^OR^EN.601.475[C]^OR^EN.601.482',
+      double_count: ['All'],
       fine_requirements: [
         {
           required_credits: 3,
@@ -3888,6 +3954,7 @@ const minorAMS_New: Minor = {
         '<br /> <em>**Note:</em> Within the entire minor, students may count only two of these three courses/course combinations: EN.553.310/EN.553.311; EN.553.420/620; EN.553.430/630.',
       criteria:
         'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3896,6 +3963,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3903,6 +3971,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3910,6 +3979,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3917,6 +3987,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3924,6 +3995,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3931,6 +4003,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3938,6 +4011,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3945,6 +4019,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3952,6 +4027,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3959,6 +4035,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3966,6 +4043,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 18,
@@ -3973,6 +4051,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^NOT^AS.110.106[C]^NOT^AS.110.107[C]^NOT^AS.110.108[C]^NOT^AS.110.109[C]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+          double_count: ['All'],
         },
       ],
     },
@@ -3983,6 +4062,7 @@ const minorAMS_New: Minor = {
       description:
         'Among the courses comprising the 18 Q credits, there must be at least four courses in the Department of Applied Mathematics and Statistics (each of these must be a 3- or 4-credit course).',
       criteria: 'Q[A]^AND^EN Applied Mathematics & Statistics[D]',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -3991,6 +4071,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3998,6 +4079,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4005,6 +4087,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4012,6 +4095,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4019,6 +4103,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4026,6 +4111,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4033,6 +4119,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4040,6 +4127,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4047,6 +4135,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4054,6 +4143,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4061,6 +4151,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
+            double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4068,6 +4159,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
+            double_count: ['All'],
         },
       ],
     },
@@ -4080,6 +4172,7 @@ const minorAMS_New: Minor = {
         'of which at least two must be in the Department of Applied Mathematics and Statistics**.<br />' +
         '</br /> **A student may count the combination of (AS.110.201 Linear Algebra or AS.110.212 Honors Linear Algebra) AND AS.110.302 Differential Equations and Applications in place of ONE of the required 300-level courses within the AMS Department',
       criteria: 'Q[A]^AND^(300[L]^OR^400[L])',
+      double_count: ['All'],
       pathing: 1,
       fine_requirements: [
         {
@@ -4088,6 +4181,7 @@ const minorAMS_New: Minor = {
             '<b>AMS Courses:</b> <br />At least two upper-level courses must be in the Department of Applied Mathematics and Statistics.**',
           criteria:
             '(300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D]',
+          double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -4095,6 +4189,7 @@ const minorAMS_New: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.201 Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.201[C]^OR^AS.110.302[C]',
+          double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -4102,6 +4197,7 @@ const minorAMS_New: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.212 Honors Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.212[C]^OR^AS.110.302[C]',
+          double_count: ['All'],
         },
       ],
     },
@@ -4114,6 +4210,7 @@ const minorAMS_New: Minor = {
         'an approved semester course in scientific computing, chosen from 110.445, 553.385, 553.400, 553.413, 553.432, 553.433, 553.436, 553.450, 553.463, 553.467, 553.481, 553.488, 553.493, 553.494, 601.433, 601.475, 601.482 or one of the courses approved to meet the AMS Master’s/PhD Computing Requirement.',
       criteria:
         'AS.110.445[C]^OR^EN.553.385[C]^OR^EN.553.400[C]^OR^EN.553.413[C]^OR^EN.553.432[C]^OR^EN.553.433[C]^OR^EN.553.436[C]^OR^EN.553.450[C]^OR^EN.553.463[C]^OR^EN.553.467[C]^OR^EN.553.481[C]^OR^EN.553.488[C]^OR^EN.553.493[C]^OR^EN.553.494[C]^OR^EN.601.433[C]^OR^EN.601.475[C]^OR^EN.601.482[C]',
+      double_count: ['All'],
       fine_requirements: [
         {
           required_credits: 3,

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -1513,7 +1513,8 @@ const bsCBE: Major = {
       min_credits_per_course: 3,
       description:
         'Take one of the following course options for Product Design.',
-      criteria: 'EN.540.314[C]^OR^EN.540.309[C]^OR^EN.540.310[C]^OR^EN.500.308[C]^OR^EN.500.309[C]',
+      criteria:
+        'EN.540.314[C]^OR^EN.540.309[C]^OR^EN.540.310[C]^OR^EN.500.308[C]^OR^EN.500.309[C]',
       pathing: 1,
       fine_requirements: [
         {
@@ -1704,7 +1705,7 @@ const bsCBE: Major = {
         'Students are required to fulfill the university’s requirement of two writing intensive courses, ' +
         'each at least 3 credits. Students must receive at least a C- grade or better in these writing courses.',
       criteria: 'Written Intensive[W]',
-      double_count: ['All'], 
+      double_count: ['All'],
     },
   ],
 };
@@ -2156,7 +2157,13 @@ const bsAMS: Major = {
         'Courses coded Natural Sciences. Laboratory courses that accompany Natural Science courses may' +
         ' be used in reaching this total. (Courses used to meet the requirements above may be counted toward this total.)',
       criteria: 'N[A]',
-      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
+      double_count: [
+        'Math',
+        'Computer Languages and Programming',
+        'Area of Focus',
+        'Scientific Computing',
+        'Writing Intensive',
+      ],
     },
     {
       name: 'Quantitative Studies',
@@ -2166,7 +2173,13 @@ const bsAMS: Major = {
         'Courses coded Quantitative Studies totaling 40 credits of which at least 18 credits must be in courses ' +
         'numbered 300 or higher. (Courses used to meet the requirements above may be counted toward this total.)',
       criteria: 'Q[A]',
-      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
+      double_count: [
+        'Math',
+        'Computer Languages and Programming',
+        'Area of Focus',
+        'Scientific Computing',
+        'Writing Intensive',
+      ],
       fine_requirements: [
         {
           description:
@@ -2187,7 +2200,13 @@ const bsAMS: Major = {
         'they don’t carry an ‘H’ or ‘S’ designator.',
       criteria:
         'AS Center for Language Education[D]^OR^AS Modern Languages and Literatures[D]^OR^H[A]^OR^S[A]',
-      double_count: ['Math', 'Computer Languages and Programming', 'Area of Focus', 'Scientific Computing', 'Writing Intensive'],
+      double_count: [
+        'Math',
+        'Computer Languages and Programming',
+        'Area of Focus',
+        'Scientific Computing',
+        'Writing Intensive',
+      ],
     },
     {
       name: 'Writing Intensive',
@@ -3761,7 +3780,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3769,7 +3788,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3777,7 +3796,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3785,7 +3804,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3793,7 +3812,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3801,7 +3820,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3809,7 +3828,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3817,7 +3836,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3825,7 +3844,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3833,7 +3852,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -3841,7 +3860,7 @@ const minorAMS_Old: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
       ],
     },
@@ -3863,7 +3882,7 @@ const minorAMS_Old: Minor = {
             '<b>AMS Courses:</b> <br />At least two upper-level courses must be in the Department of Applied Mathematics and Statistics.**',
           criteria:
             '(300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -3871,7 +3890,7 @@ const minorAMS_Old: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.201 Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.201[C]^OR^AS.110.302[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 9,
@@ -3879,7 +3898,7 @@ const minorAMS_Old: Minor = {
             '<b>**Alternate Route:</b> <br />One upper-level course from the Department of Applied Mathematics and Statistics, and (AS.110.212 Honors Linear Algebra AND AS.110.302 Differential Equations and Applications).',
           criteria:
             '((300[L]^OR^400[L])^AND^EN Applied Mathematics & Statistics[D])^OR^AS.110.212[C]^OR^AS.110.302[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
       ],
     },
@@ -4079,7 +4098,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4087,7 +4106,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.420 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^AS.110.113[C]^NOT^EN.553.310[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4095,7 +4114,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.620 Introduction to Probability count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4103,7 +4122,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4111,7 +4130,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.310 Probability & Statistics for the Physical Sciences & Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4119,7 +4138,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4127,7 +4146,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.311 Probability and Statistics for the Biological Sciences and Engineering and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.420[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4135,7 +4154,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4143,7 +4162,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4151,7 +4170,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.620 Introduction to Probability and EN.553.430 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.420[C]^NOT^EN.553.630[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
         {
           required_credits: 12,
@@ -4159,7 +4178,7 @@ const minorAMS_New: Minor = {
             '**Only EN.553.420 Introduction to Probability and EN.553.630 Introduction to Statistics count towards minor.',
           criteria:
             'Q[A]^AND^EN Applied Mathematics & Statistics[D]^NOT^EN.553.310[C]^NOT^EN.553.311[C]^NOT^EN.553.620[C]^NOT^EN.553.430[C]',
-            double_count: ['All'],
+          double_count: ['All'],
         },
       ],
     },


### PR DESCRIPTION
## double_count redefined
The default value (or the absence) of `double_count` signified that the distribution could overlap freely with any other. We did this because it saved us typing. To avoid confusion, however, we are changing the logic so that the absence of `double_count` indicates no double count.

## Implementation 
- modified double_count field checking for distributions and fine requirements 
<img width="722" alt="Screen Shot 2022-07-27 at 8 44 27 PM" src="https://user-images.githubusercontent.com/90944895/181238824-1b53d814-e71b-43dd-97aa-2b9f0af450b9.png">
- removed all instances of `double_count: ['N/A']` in majors.tsx
- add `double_count: ['All']` in majors.tsx where necessary 

## double_count guide 
- undefined or []: cannot double count with any (aka is exclusive) 
- ['A', 'B']: can double count with A or B 
- ['All']: can overlap with all distributions 
    - saves us from typing all the distributions 

## testing 
Tested locally. Other open PRs will need to pull these changes and ensure their code is compatible with the new `double_count`. 