### PR TITLE
DEV-32 Comment deletion is broken

### DIFF
--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -258,10 +258,11 @@ const Comments: FC<{
     try {
       let comment_id: string = '';
       const threads = await userService.getThreads(plan._id, false, null);
-      for (let thread of threads.data) {
+      for (let thread of threads.data.data) {
         for (let comment of thread.comments) {
           if (comment._id === key) {
             comment_id = comment._id;
+            break;
           }
         }
       }

--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -265,7 +265,7 @@ const Comments: FC<{
             const commentIndex = thread.comments
               .map((e) => e._id)
               .indexOf(comment_id);
-            thread.comments.splice(commentIndex);
+            thread.comments.splice(commentIndex, 1);
             dispatch(updateThreads(threads.data.data));
             break;
           }

--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -262,6 +262,11 @@ const Comments: FC<{
         for (let comment of thread.comments) {
           if (comment._id === key) {
             comment_id = comment._id;
+            const commentIndex = thread.comments
+              .map((e) => e._id)
+              .indexOf(comment_id);
+            thread.comments.splice(commentIndex);
+            dispatch(updateThreads(threads.data.data));
             break;
           }
         }


### PR DESCRIPTION
### Description
After a user deletes a comment, if the page reloads (e.g. page is manually refreshed, user opens comments list, user replies to another comment), the deleted comment reappears. The issue was occuring because in the comments deleteHandler written over the summer, the Redux state was not being updated. 

### Implementation
The comments deleteHandler updates the Redux state using updateThreads. 

### Testing
Tested locally. Created new comments and deleted them. 