### PR TITLE
fix: fixed but with not being able to search future spring courses

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -117,7 +117,7 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
     // If the current year is the same as the year of the semester or later,
     // we need to check Fall, Spring, Intersession, and Summer to see if we need to increase year value.
     if (
-      (semester === 'Spring' && date.getMonth() >= 9) ||
+      (semester === 'Spring' && date.getMonth() >= 10) ||
       (semester === 'Intersession' && date.getMonth() === 11) ||
       (semester === 'Summer' &&
         date.getMonth() >= 2 &&


### PR DESCRIPTION
## Bug 
no search results for spring semesters in future (e.g. Spring 2023 and onwards) 

## Cause 
Request to '/api/search' had param year: 2023 for which obviously we don't have matching courses yet. Code in Form.tsx assumes that SIS will have added spring courses by October but obviously, this has not been the case as of now. That is why this bug occurred on October 1st. The year param should only be included IF course data is available for that year. 

## Future notes 
We may want to check if we have courses for Spring 202X before querying for it. 