### PR TITLE
DEV-36: fix bug with double_count in bsCS_new

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -258,7 +258,6 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
           checkRequirementSatisfied(fineReq, courseObj) // check if course satisfies fine req
         ) {
           // update fine requirements
-          console.log(reqs[i][1][j], courseObj);
           reqs[i][1][j].fulfilled_credits += parseInt(courseObj.credits);
           fineDoubleCount = fineReq.double_count;
         }

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -214,13 +214,15 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       if (
         distDoubleCount &&
         (distDoubleCount.includes(req.name) ||
-          distDoubleCount.includes('All')) &&
-        (req.fulfilled_credits < req.required_credits ||
-          (req.required_credits === 0 && req.fulfilled_credits === 0)) &&
+          distDoubleCount.includes('All')) && 
         checkRequirementSatisfied(req, courseObj)
       ) {
-        reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
-        distDoubleCount = req.double_count; // set double_count, if any
+        // update credit only if credit requirement not met
+        if (req.fulfilled_credits < req.required_credits ||
+          (req.required_credits === 0 && req.fulfilled_credits === 0)) {
+            reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
+            distDoubleCount = req.double_count; // set double_count, if any
+        }
         // for each fine req, see if course satisfies fine requirements
         processFines(reqs, courseObj, i);
       }

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3108,7 +3108,7 @@ const bsCS_Old: Major = {
       description:
         "For more information please visit the <a href='https://www.cs.jhu.edu/undergraduate-studies/academics/ugrad-advising-manual/'>" +
         'major degree requirement</a> section on the department website.',
-      criteria: 'EN Computer Science[D]^OR^EN.500.112[C]^OR^EN.660.400[C]',
+      criteria: 'EN Computer Science[D]^OR^EN.500.112[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
       double_count: [
         'Mathematics',
         'Humanities/Social Sciences',
@@ -3387,7 +3387,7 @@ const bsCS_New: Major = {
         "For more information please visit the <a href='https://www.cs.jhu.edu/undergraduate-studies/academics/ugrad-advising-manual/'>" +
         'major degree requirement</a> section on the department website.',
       criteria:
-        'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]',
+        'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]^OR^EN.600.104[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
       double_count: [
         'Computer Science Classifications',
         'Mathematics',
@@ -3613,7 +3613,7 @@ const baCS_New: Major = {
         "For more information please visit the <a href='https://www.cs.jhu.edu/2021undergraduate-advising-manual/'>" +
         'major degree requirement</a> section on the department website.',
       criteria:
-        'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]',
+        'EN Computer Science[D]^OR^CSCI-OTHER[T]^OR^Gateway Computing[N]^OR^EN.600.104[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
       double_count: ['All'],
       fine_requirements: [
         {

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3412,7 +3412,7 @@ const bsCS_New: Major = {
           required_credits: 21,
           criteria:
             'EN.500.112[C]^OR^EN.500.113[C]^OR^EN.500.114[C]^OR^EN.601.220[C]^OR^EN.601.226[C]' +
-            '^OR^EN.601.229[C]^OR^EN.601.230[C]^OR^EN.601.433[C]^OR^EN.601.231',
+            '^OR^EN.601.229[C]^OR^EN.601.230[C]^OR^EN.601.433[C]^OR^EN.601.231[C]',
         },
         {
           description:


### PR DESCRIPTION
## Bugs with degree progress feature & bsCS_new
Testing with [Matthew Liu's plan](https://ucredit.me/share?_id=61e644ff68480b0004c9e6e9) which should satisfy every distribution and fine requirement. 
1. Practical Ethics for Leaders does not satisfy Computer Science > Computer Ethics 
2. Lower Level Undergraduate not fulfilled despite all course requirements being met 
3. Computer Science Classifications distribution fine requirements not being fulfilled when there are 3 applicable courses: Artificial Intelligence, OOSE, and Functional Programming 

## Temporary fix 
1. add Practical Ethics course number to distribution criteria string 
2. (and 3) double_count is restricting us from considering other distributions. Only update double_count if course satisfies AND updates credits for general distribution. ALWAYS consider a course for all fine requirements. That way even if credit requirements are met, we still consider a course for fine requirements. 

update: implement it so that we insert a course if the planned credit count <= total or all fine reqs are not satisfied yet

## Notes
Needs more testing with other majors. 

![image (2)](https://user-images.githubusercontent.com/90944895/193667977-839a4aeb-cc40-45f3-a797-d4b95cd1924a.png)
![image (3)](https://user-images.githubusercontent.com/90944895/193668006-031df4a0-dd81-49a5-925a-ea9dbbe0e5a3.png)

