### PR TITLE
DEV-47&50: fixed bugs within BME and CS

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -214,15 +214,17 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       if (
         distDoubleCount &&
         (distDoubleCount.includes(req.name) ||
-          distDoubleCount.includes('All')) && 
+          distDoubleCount.includes('All')) &&
         checkRequirementSatisfied(req, courseObj)
       ) {
         console.log(courseObj.title, req.name, distDoubleCount);
         // update credit only if credit requirement not met
-        if (req.fulfilled_credits < req.required_credits ||
-          (req.required_credits === 0 && req.fulfilled_credits === 0)) {
-            reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
-            distDoubleCount = req.double_count; // set double_count, if any
+        if (
+          req.fulfilled_credits < req.required_credits ||
+          (req.required_credits === 0 && req.fulfilled_credits === 0)
+        ) {
+          reqs[i][1][0].fulfilled_credits += parseInt(courseObj.credits);
+          distDoubleCount = req.double_count; // set double_count, if any
         }
         // for each fine req, see if course satisfies fine requirements
         processFines(reqs, courseObj, i);

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -217,6 +217,7 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
           distDoubleCount.includes('All')) && 
         checkRequirementSatisfied(req, courseObj)
       ) {
+        console.log(courseObj.title, req.name, distDoubleCount);
         // update credit only if credit requirement not met
         if (req.fulfilled_credits < req.required_credits ||
           (req.required_credits === 0 && req.fulfilled_credits === 0)) {
@@ -279,7 +280,7 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
           numPaths -= 1;
         }
       }
-      if (numPaths === 0) {
+      if (numPaths <= 0) {
         reqGroup[1] = satisfiedFineRequirements;
       }
     }

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -1915,13 +1915,6 @@ const bsBME: Major = {
       ],
     },
     {
-      name: 'Other Electives',
-      required_credits: 9,
-      min_credits_per_course: 1,
-      description: 'Select 9 credits from any area.',
-      criteria: 'H[A]^OR^S[A]^OR^Q[A]^OR^N[A]^OR^E[A]',
-    },
-    {
       name: 'Humanities and Social Sciences',
       required_credits: 18,
       min_credits_per_course: 3,
@@ -1944,6 +1937,13 @@ const bsBME: Major = {
       ],
     },
     {
+      name: 'Other Electives',
+      required_credits: 9,
+      min_credits_per_course: 1,
+      description: 'Select 9 credits from any area.',
+      criteria: 'H[A]^OR^S[A]^OR^Q[A]^OR^N[A]^OR^E[A]',
+    },
+    {
       name: 'Writing Intensive',
       required_credits: 6,
       min_credits_per_course: 3,
@@ -1953,6 +1953,7 @@ const bsBME: Major = {
       criteria: 'Written Intensive[W]',
       double_count: ['All'],
     },
+
   ],
 };
 

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -1942,6 +1942,7 @@ const bsBME: Major = {
       min_credits_per_course: 1,
       description: 'Select 9 credits from any area.',
       criteria: 'H[A]^OR^S[A]^OR^Q[A]^OR^N[A]^OR^E[A]',
+      double_count: ['Writing Intensive'],
     },
     {
       name: 'Writing Intensive',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -1954,7 +1954,6 @@ const bsBME: Major = {
       criteria: 'Written Intensive[W]',
       double_count: ['All'],
     },
-
   ],
 };
 
@@ -3110,7 +3109,8 @@ const bsCS_Old: Major = {
       description:
         "For more information please visit the <a href='https://www.cs.jhu.edu/undergraduate-studies/academics/ugrad-advising-manual/'>" +
         'major degree requirement</a> section on the department website.',
-      criteria: 'EN Computer Science[D]^OR^EN.500.112[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
+      criteria:
+        'EN Computer Science[D]^OR^EN.500.112[C]^OR^EN.601.104[C]^OR^EN.660.400[C]',
       double_count: [
         'Mathematics',
         'Humanities/Social Sciences',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3315,7 +3315,7 @@ const bsCS_Old: Major = {
     },
     {
       name: 'Basic Sciences',
-      required_credits: 16,
+      required_credits: 8,
       min_credits_per_course: 1,
       description:
         'At least two semesters of physics or two semesters of chemistry, with the associated laboratories, must be included.',
@@ -3545,7 +3545,7 @@ const bsCS_New: Major = {
     },
     {
       name: 'Basic Sciences',
-      required_credits: 10,
+      required_credits: 8,
       min_credits_per_course: 1,
       description:
         'At least two semesters of physics or two semesters of chemistry, with the associated laboratories, must be included.',


### PR DESCRIPTION
## Bugs
- CS Science credit requirements should be 10, not 8 
- Intro to anthropology should count towards Writing intensive requirements in BME 
- pathing=1 is satisfied but Focus Area distribution of BME is not satisfied  
For a better description, see [JIRA](https://ucredit-fall22.atlassian.net/jira/software/c/projects/DEV/boards/1?modal=detail&selectedIssue=DEV-50) board. 

## Fixes 
- edit bscs_old and bscs_new in majors.tsx 
- change the order of distribution bars in BME 
   - before, electives distribution was placed before writing intensive
   - electives has no `double counting` distributions 
   - hence the course was never considered for writing intensive 
   - make electives only double count with writing intensive (other dists -> elective -> writing intensive) 
- when multiple paths are satisfied at once, the condition numPaths === 0 is false 
   - numPaths < 0 should also satisfy pathing requirement 

