### PR TITLE
DEV-29 Reviewer reloads reviewee’s plan and returns to own plan, reviewee’s plan still displays

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -48,10 +48,8 @@ const Dash: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (user._id === 'noUser') {
-      if (typeof router.query.plan !== 'undefined') {
-        toast.error('You do not have access to this plan!');
-      }
+    if (user._id === 'noUser' && typeof router.query.plan !== 'undefined') {
+      toast.error('You do not have access to this plan!');
     }
     if (!router.query || !router.query.mode) {
       if (planList.length > 0) dispatch(updateSelectedPlan(planList[0]));

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -11,14 +11,13 @@ import { ReviewMode, User } from '../lib/resources/commonTypes';
 import { useRouter } from 'next/router';
 import { userService } from '../lib/services';
 import axios from 'axios';
-import { getAPI, guestUser } from '../lib/resources/assets';
+import { getAPI } from '../lib/resources/assets';
 import {
   initialPlan,
   updateSelectedPlan,
 } from '../lib/slices/currentPlanSlice';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { useRoutes } from 'react-router';
 
 const Dash: React.FC = () => {
   const user: User = useSelector(selectUser);

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -90,14 +90,16 @@ const Dash: React.FC = () => {
           setMode(ReviewMode.View);
           return;
         }
-        router.push('/dashboard');
-        toast.error('You do not have access to this plan!');
+        if (router.query.plan) {
+          router.push('/dashboard');
+          toast.error('You do not have access to this plan!');
+        }
       } catch (e) {
         console.log(e);
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.query]); // router.query, change when reviewer -> planning dashboard
+  }, [router.query]);
 
   return (
     <>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -51,7 +51,7 @@ const Dash: React.FC = () => {
       // we are guest looking at someone else’s plan
       // if they try to look at someone else’s plan, return error message
       if (typeof router.query.plan !== 'undefined') {
-        // toast.error('You do not have access to this plan!');
+        toast.error('You do not have access to this plan!');
         return;
       }
     }
@@ -85,10 +85,7 @@ const Dash: React.FC = () => {
             dispatch(updateSelectedPlan(res.data));
             dispatch(updateReviewMode(ReviewMode.View));
             setMode(ReviewMode.View);
-          } // else {
-          //   // if no, don't display plan at all, display toast error
-          //   toast.error('You do not have access to this plan!');
-          // }
+          }
         }
       } catch (e) {
         console.log(e);

--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -86,7 +86,14 @@ const Login: React.FC = () => {
 
           const referrer = router.query.referrer as string;
           if (referrer) redirectToReferrer();
-          else router.push('/dashboard');
+          else if (
+            typeof router.query.plan !== 'undefined' &&
+            typeof router.query.mode !== 'undefined'
+          ) {
+            router.push(
+              `/dashboard?plan=${router.query.plan}&mode=${router.query.mode}`,
+            );
+          } else router.push('/dashboard');
         } else {
           dispatch(updateLoginCheck(true));
           setFinishedLoginCheck(true);
@@ -146,7 +153,14 @@ const Login: React.FC = () => {
           '; path=/';
         const referrer = router.query.referrer as string;
         if (referrer) redirectToReferrer();
-        else router.push('/dashboard');
+        else if (
+          typeof router.query.plan !== 'undefined' &&
+          typeof router.query.mode !== 'undefined'
+        ) {
+          router.push(
+            `/dashboard?plan=${router.query.plan}&mode=${router.query.mode}`,
+          );
+        } else router.push('/dashboard');
       })
       .catch((err) => {
         console.log('Backdoor verfication failed!', err);


### PR DESCRIPTION
### Description
If a user starts on their reviewee’s plan then tries to return to their own plan, the reviewee’s plan is displayed instead of their own plan. When a user inspects their reviewee’s plan, the URL contains characters after [ucredit.me/dashboard](http://ucredit.me/dashboard) (e.g. https://ucredit.me/dashboard?plan=61e4bfe7d834e2000448576d&mode=view). If the user refreshes while viewing the reviewee’s plan, the page reloads and redirects to /login then /dashboard. The page still displays the reviewee’s plan but the URL becomes [ucredit.me/dashboard](http://ucredit.me/dashboard), without the subsequent characters. If the user then tries to return to their own planning dashboard, the reviewee’s plan still displays.

### Implementation
Implementation is in pages/dashboard.tsx and pages/login/[[...token]].tsx. Used /dashboard and /login router.query to "remember" the plan id and the mode that the user tries to access. 

Users cannot access plans that they do not have permissions for. Users who are guests or not logged in cannot access anyone else's plan; they are redirected to the login page. Logged in users who are reviewing someone else's plan can view that person's plan.  Logged in users who are not reviewing someone else's plan will see an error message if they try to access this person's plan. Users who try to access their own plan through the URL (with plan and mode) can edit their own plan.

### Testing
Tested locally. Below are the test cases. 

1. log in as jdeng25 (reviewing kyang53), try kyang53’s url, displays kyang53’s plan in view mode, refresh page, return to reviewer dashboard, return to planning dashboard
2. log in as mpark63 (not reviewing kyang53), try kyang53’s url, displays mpark63’s plan & error message
3. log in as kyang53 (self), try kyang53’s url, displays kyang53’s plan in edit mode
4. log in as guest user, try kyang53’s url, redirects to login, log in as jdeng25 (reviewer), displays kyang53’s plan in view mode
5. log in as guest user, try kyang53’s url, redirects to login, continue as guest user, redirects to create new guest plan
6. do not log in, try kyang53’s url, redirects to login

### Notes
In the future, if we implement remembering a guest's plans via cookies or localstorage, there may be issues. 