### PR TITLE
Make notification appear in reverse chronological order

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -79,7 +79,7 @@ const MyApp: React.FC<{
         position="bottom-center"
         autoClose={4000}
         hideProgressBar={true}
-        newestOnTop={false}
+        newestOnTop={true}
         closeOnClick
         rtl={false}
         pauseOnFocusLoss


### PR DESCRIPTION
We discovered that users may not realize their issue if they have multiple notifications, because users would have to scroll down to find the latest notification. Now, the order of notifications has been reversed, so the most recent notification appears first.
