### PR TITLE
Prevent Notification Duplication (DEV-18)

### DIFF
--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -94,7 +94,7 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
           }
         }
         toast.success('Plan name changed to ' + planName + '!', {
-          toastId: 'plan name changed'
+          toastId: 'plan name changed',
         });
         setEditName(false);
         dispatch(updatePlanList(newPlanList));
@@ -126,7 +126,7 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
   const handleMajorChange = (event, newValues) => {
     if (newValues.length === 0) {
       toast.error('You must have at least one major!', {
-        toastId: 'one major'
+        toastId: 'one major',
       });
       return;
     }
@@ -189,7 +189,7 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
     navigator.clipboard.writeText(shareableURL).then(() => {
       navigator.clipboard.writeText(shareableURL).then(() => {
         toast.info('Share link copied to Clipboard!', {
-          toastId: 'share link copied'
+          toastId: 'share link copied',
         });
       });
     });
@@ -229,13 +229,13 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
           dispatch(updateSelectedPlan(updatedPlanList[0]));
           dispatch(updatePlanList(updatedPlanList));
           toast.success('New Year added!', {
-            toastId: 'new year added'
+            toastId: 'new year added',
           });
         })
         .catch((err) => console.log(err));
     } else {
       toast.error("Can't add more than 8 years!", {
-        toastId: 'too many years'
+        toastId: 'too many years',
       });
     }
   };

--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -93,7 +93,9 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
             newPlanList[i] = { ...newUpdatedPlan };
           }
         }
-        toast.success('Plan name changed to ' + planName + '!');
+        toast.success('Plan name changed to ' + planName + '!', {
+          toastId: 'plan name changed'
+        });
         setEditName(false);
         dispatch(updatePlanList(newPlanList));
       })
@@ -123,7 +125,9 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
 
   const handleMajorChange = (event, newValues) => {
     if (newValues.length === 0) {
-      toast.error('You must have at least one major!');
+      toast.error('You must have at least one major!', {
+        toastId: 'one major'
+      });
       return;
     }
 
@@ -184,7 +188,9 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
       window.location.origin + '/share?_id=' + currentPlan._id;
     navigator.clipboard.writeText(shareableURL).then(() => {
       navigator.clipboard.writeText(shareableURL).then(() => {
-        toast.info('Share link copied to Clipboard!');
+        toast.info('Share link copied to Clipboard!', {
+          toastId: 'share link copied'
+        });
       });
     });
   };
@@ -222,11 +228,15 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
           };
           dispatch(updateSelectedPlan(updatedPlanList[0]));
           dispatch(updatePlanList(updatedPlanList));
-          toast.success('New Year added!');
+          toast.success('New Year added!', {
+            toastId: 'new year added'
+          });
         })
         .catch((err) => console.log(err));
     } else {
-      toast.error("Can't add more than 8 years!");
+      toast.error("Can't add more than 8 years!", {
+        toastId: 'too many years'
+      });
     }
   };
   return (

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -64,7 +64,7 @@ const HandlePlanShareDummy = () => {
           {
             closeOnClick: false,
             autoClose: false,
-            toastId: 'failed to import'
+            toastId: 'failed to import',
           },
         );
       });
@@ -303,7 +303,7 @@ const HandlePlanShareDummy = () => {
       toast.success('Plan Imported!', {
         autoClose: 5000,
         closeOnClick: false,
-        toastId: 'plan imported'
+        toastId: 'plan imported',
       });
       dispatch(updateAddingPlanStatus(false));
     }

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -64,6 +64,7 @@ const HandlePlanShareDummy = () => {
           {
             closeOnClick: false,
             autoClose: false,
+            toastId: 'failed to import'
           },
         );
       });
@@ -302,6 +303,7 @@ const HandlePlanShareDummy = () => {
       toast.success('Plan Imported!', {
         autoClose: 5000,
         closeOnClick: false,
+        toastId: 'plan imported'
       });
       dispatch(updateAddingPlanStatus(false));
     }

--- a/lib/components/dashboard/HandleUserInfoSetupDummy.tsx
+++ b/lib/components/dashboard/HandleUserInfoSetupDummy.tsx
@@ -72,7 +72,7 @@ const HandleUserInfoSetupDummy: React.FC = () => {
         dispatch(updateSelectedPlan(retrievedPlans[0]));
       }
       toast('Retrieved ' + retrievedPlans.length + ' plans!', {
-        toastId: 'retrieved plans'
+        toastId: 'retrieved plans',
       });
     }
 

--- a/lib/components/dashboard/HandleUserInfoSetupDummy.tsx
+++ b/lib/components/dashboard/HandleUserInfoSetupDummy.tsx
@@ -71,7 +71,9 @@ const HandleUserInfoSetupDummy: React.FC = () => {
       if (!curPlan || curPlan._id === 'noPlan') {
         dispatch(updateSelectedPlan(retrievedPlans[0]));
       }
-      toast('Retrieved ' + retrievedPlans.length + ' plans!');
+      toast('Retrieved ' + retrievedPlans.length + ' plans!', {
+        toastId: 'retrieved plans'
+      });
     }
 
     if (

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -166,7 +166,7 @@ const CourseList: FC<Props> = ({ mode }) => {
   const swapYear = (sourceIndex: number, destIndex: number): void => {
     if (sourceIndex === 0 || destIndex === 0) {
       toast.error("Can't swap with AP Equivalent section!", {
-        toastId: 'no AP swap'
+        toastId: 'no AP swap',
       });
       return;
     }
@@ -235,7 +235,7 @@ const CourseList: FC<Props> = ({ mode }) => {
         !checkDestValid(course, destination, retrievedCourses)
       ) {
         toast.error("Course isn't usually held this semester!", {
-          toastId: 'no course this semester'
+          toastId: 'no course this semester',
         });
       } else {
         const body = {
@@ -256,8 +256,8 @@ const CourseList: FC<Props> = ({ mode }) => {
         if (!res.ok) {
           console.log('ERROR:', res);
         } else {
-          toast.success('Successfully moved course!',  {
-            toastId: 'moved course'
+          toast.success('Successfully moved course!', {
+            toastId: 'moved course',
           });
         }
         res = await res.json();

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -165,7 +165,9 @@ const CourseList: FC<Props> = ({ mode }) => {
    */
   const swapYear = (sourceIndex: number, destIndex: number): void => {
     if (sourceIndex === 0 || destIndex === 0) {
-      toast.error("Can't swap with AP Equivalent section!");
+      toast.error("Can't swap with AP Equivalent section!", {
+        toastId: 'no AP swap'
+      });
       return;
     }
     const yearArr: Year[] = [...currentPlan.years];
@@ -232,7 +234,9 @@ const CourseList: FC<Props> = ({ mode }) => {
         retrievedCourses.length !== 0 &&
         !checkDestValid(course, destination, retrievedCourses)
       ) {
-        toast.error("Course isn't usually held this semester!");
+        toast.error("Course isn't usually held this semester!", {
+          toastId: 'no course this semester'
+        });
       } else {
         const body = {
           newYear: destYear._id,
@@ -252,7 +256,9 @@ const CourseList: FC<Props> = ({ mode }) => {
         if (!res.ok) {
           console.log('ERROR:', res);
         } else {
-          toast.success('Successfully moved course!');
+          toast.success('Successfully moved course!',  {
+            toastId: 'moved course'
+          });
         }
         res = await res.json();
         const updatedCourse = res.data;

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -255,7 +255,9 @@ const Semester: FC<{
       if (cartOpen) dispatch(updateShowingCart(true));
       else dispatch(clearSearch());
       dispatch(updateCartAdd(false));
-      toast.success(version.title + ' added!');
+      toast.success(version.title + ' added!', {
+        toastId: 'title added'
+      });
     } else {
       console.log('Failed to add', data.errors);
     }

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -256,7 +256,7 @@ const Semester: FC<{
       else dispatch(clearSearch());
       dispatch(updateCartAdd(false));
       toast.success(version.title + ' added!', {
-        toastId: 'title added'
+        toastId: 'title added',
       });
     } else {
       console.log('Failed to add', data.errors);

--- a/lib/components/dashboard/course-list/YearSettingsDropdown.tsx
+++ b/lib/components/dashboard/course-list/YearSettingsDropdown.tsx
@@ -113,7 +113,9 @@ const YearSettingsDropdown: FC<{
           console.log(err);
         });
     } else {
-      toast.error('Year already exists');
+      toast.error('Year already exists', {
+        toastId: 'year exists'
+      });
     }
   };
 

--- a/lib/components/dashboard/course-list/YearSettingsDropdown.tsx
+++ b/lib/components/dashboard/course-list/YearSettingsDropdown.tsx
@@ -114,7 +114,7 @@ const YearSettingsDropdown: FC<{
         });
     } else {
       toast.error('Year already exists', {
-        toastId: 'year exists'
+        toastId: 'year exists',
       });
     }
   };

--- a/lib/components/dashboard/degree-info/ShareLinksPopup.tsx
+++ b/lib/components/dashboard/degree-info/ShareLinksPopup.tsx
@@ -16,9 +16,8 @@ const ShareLinksPopup: FC<{
     navigator.clipboard.writeText(link).then(() => {
       navigator.clipboard.writeText(link).then(() => {
         toast.info('Copied to Clipboard!', {
-          toastId: 'share link copied'
+          toastId: 'share link copied',
         });
-        
       });
     });
   };

--- a/lib/components/dashboard/degree-info/ShareLinksPopup.tsx
+++ b/lib/components/dashboard/degree-info/ShareLinksPopup.tsx
@@ -15,7 +15,10 @@ const ShareLinksPopup: FC<{
   const copyToClipBoard = () => {
     navigator.clipboard.writeText(link).then(() => {
       navigator.clipboard.writeText(link).then(() => {
-        toast.info('Copied to Clipboard!');
+        toast.info('Copied to Clipboard!', {
+          toastId: 'share link copied'
+        });
+        
       });
     });
   };

--- a/lib/components/dashboard/menus/PlanEditMenu.tsx
+++ b/lib/components/dashboard/menus/PlanEditMenu.tsx
@@ -91,7 +91,9 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
             newPlanList[i] = { ...newUpdatedPlan };
           }
         }
-        toast.success('Plan name changed to ' + planName + '!');
+        toast.success('Plan name changed to ' + planName + '!', {
+          toastId:'plan name changed'
+        });
         setEditName(false);
         dispatch(updatePlanList(newPlanList));
       })
@@ -130,7 +132,9 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
 
   const handleMajorChange = (event: any) => {
     if (event.length === 0) {
-      toast.error('You must have at least one major!');
+      toast.error('You must have at least one major!', {
+        toastId: 'one major'
+      });
       return;
     }
     const newMajors = event.map((option) => option.label);
@@ -226,7 +230,9 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
         })
         .catch((err) => console.log(err));
     } else {
-      toast.error("Can't add more than 8 years!");
+      toast.error("Can't add more than 8 years!", {
+        toastId: 'too many years'
+      });
     }
   };
 

--- a/lib/components/dashboard/menus/PlanEditMenu.tsx
+++ b/lib/components/dashboard/menus/PlanEditMenu.tsx
@@ -92,7 +92,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
           }
         }
         toast.success('Plan name changed to ' + planName + '!', {
-          toastId:'plan name changed'
+          toastId: 'plan name changed',
         });
         setEditName(false);
         dispatch(updatePlanList(newPlanList));
@@ -133,7 +133,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
   const handleMajorChange = (event: any) => {
     if (event.length === 0) {
       toast.error('You must have at least one major!', {
-        toastId: 'one major'
+        toastId: 'one major',
       });
       return;
     }
@@ -231,7 +231,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
         .catch((err) => console.log(err));
     } else {
       toast.error("Can't add more than 8 years!", {
-        toastId: 'too many years'
+        toastId: 'too many years',
       });
     }
   };

--- a/lib/components/dashboard/menus/reviewers/CurrentReviewers.tsx
+++ b/lib/components/dashboard/menus/reviewers/CurrentReviewers.tsx
@@ -35,7 +35,7 @@ const CurrentReviewers: FC<{
             {
               autoClose: 5000,
               closeOnClick: false,
-              toastId: 'plan sent'
+              toastId: 'plan sent',
             },
           );
         }
@@ -45,7 +45,7 @@ const CurrentReviewers: FC<{
         toast.error('Plan failed to send to ' + toName + '.', {
           autoClose: 5000,
           closeOnClick: false,
-          toastId: 'plan failed to send'
+          toastId: 'plan failed to send',
         });
       });
   };

--- a/lib/components/dashboard/menus/reviewers/CurrentReviewers.tsx
+++ b/lib/components/dashboard/menus/reviewers/CurrentReviewers.tsx
@@ -35,6 +35,7 @@ const CurrentReviewers: FC<{
             {
               autoClose: 5000,
               closeOnClick: false,
+              toastId: 'plan sent'
             },
           );
         }
@@ -44,6 +45,7 @@ const CurrentReviewers: FC<{
         toast.error('Plan failed to send to ' + toName + '.', {
           autoClose: 5000,
           closeOnClick: false,
+          toastId: 'plan failed to send'
         });
       });
   };

--- a/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
+++ b/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
@@ -43,7 +43,7 @@ const ReviewerSearchResults: FC<{
     if (reviewId) {
       await userService.removeReview(reviewId);
       toast.success('Reviewer removed', {
-        toastId: 'reviewer removed'
+        toastId: 'reviewer removed',
       });
     } else {
       if (!isPending(user._id)) {
@@ -53,11 +53,11 @@ const ReviewerSearchResults: FC<{
           currentUser._id,
         );
         toast.success('Reviewer requested', {
-          toastId: 'reviewer requested'
+          toastId: 'reviewer requested',
         });
       } else
         toast.error('You have already requested a review from this reviewer', {
-          toastId: 'reviewer already requested'
+          toastId: 'reviewer already requested',
         });
     }
   };

--- a/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
+++ b/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
@@ -42,7 +42,9 @@ const ReviewerSearchResults: FC<{
     const reviewId = isReviewer(user._id);
     if (reviewId) {
       await userService.removeReview(reviewId);
-      toast.success('Reviewer removed');
+      toast.success('Reviewer removed', {
+        toastId: 'reviewer removed'
+      });
     } else {
       if (!isPending(user._id)) {
         await userService.requestReviewerPlan(
@@ -50,9 +52,13 @@ const ReviewerSearchResults: FC<{
           user._id,
           currentUser._id,
         );
-        toast.success('Reviewer requested');
+        toast.success('Reviewer requested', {
+          toastId: 'reviewer requested'
+        });
       } else
-        toast.error('You have already requested a review from this reviewer');
+        toast.error('You have already requested a review from this reviewer', {
+          toastId: 'reviewer already requested'
+        });
     }
   };
 

--- a/lib/components/popups/ApplicationFormPopup.tsx
+++ b/lib/components/popups/ApplicationFormPopup.tsx
@@ -41,7 +41,7 @@ const ApplicationFormPopup: FC<{
       setActivateError(false);
       setActivateEmailPopup(false);
       toast.success('Application sent!', {
-        toastId: 'app sent'
+        toastId: 'app sent',
       });
     } else {
       setActivateError(true);

--- a/lib/components/popups/ApplicationFormPopup.tsx
+++ b/lib/components/popups/ApplicationFormPopup.tsx
@@ -40,7 +40,9 @@ const ApplicationFormPopup: FC<{
       });
       setActivateError(false);
       setActivateEmailPopup(false);
-      toast.success('Application sent!');
+      toast.success('Application sent!', {
+        toastId: 'app sent'
+      });
     } else {
       setActivateError(true);
     }

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -191,7 +191,7 @@ const CourseDisplayPopup: FC = () => {
         dispatch(clearSearch());
         dispatch(updatePlaceholder(false));
         toast.success('Course updated!', {
-          toastId: 'course updated'
+          toastId: 'course updated',
         });
       } else {
         console.log('Failed to add', data.errors);

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -190,7 +190,9 @@ const CourseDisplayPopup: FC = () => {
         dispatch(updateShowCourseInfo(false));
         dispatch(clearSearch());
         dispatch(updatePlaceholder(false));
-        toast.success('Course updated!');
+        toast.success('Course updated!', {
+          toastId: 'course updated'
+        });
       } else {
         console.log('Failed to add', data.errors);
       }

--- a/lib/components/popups/DeleteCoursePopup.tsx
+++ b/lib/components/popups/DeleteCoursePopup.tsx
@@ -44,7 +44,7 @@ const DeleteCoursePopup: FC = () => {
         newPlan = { ...currentPlan, years: years };
 
         toast.error(courseInfo.course.title + ' deleted!', {
-          toastId: 'course deleted'
+          toastId: 'course deleted',
         });
         dispatch(updateSelectedPlan(newPlan));
         dispatch(
@@ -61,7 +61,7 @@ const DeleteCoursePopup: FC = () => {
       });
     } else {
       toast.error('Cannot delete last year!', {
-        toastId: 'cannot delete last year'
+        toastId: 'cannot delete last year',
       });
     }
   };

--- a/lib/components/popups/DeleteCoursePopup.tsx
+++ b/lib/components/popups/DeleteCoursePopup.tsx
@@ -43,7 +43,9 @@ const DeleteCoursePopup: FC = () => {
         });
         newPlan = { ...currentPlan, years: years };
 
-        toast.error(courseInfo.course.title + ' deleted!');
+        toast.error(courseInfo.course.title + ' deleted!', {
+          toastId: 'course deleted'
+        });
         dispatch(updateSelectedPlan(newPlan));
         dispatch(
           updatePlanList(
@@ -58,7 +60,9 @@ const DeleteCoursePopup: FC = () => {
         dispatch(updateCourseToDelete(null));
       });
     } else {
-      toast.error('Cannot delete last year!');
+      toast.error('Cannot delete last year!', {
+        toastId: 'cannot delete last year'
+      });
     }
   };
 

--- a/lib/components/popups/DeletePlanPopup.tsx
+++ b/lib/components/popups/DeletePlanPopup.tsx
@@ -35,7 +35,9 @@ const DeletePlanPopup: FC = () => {
         method: 'DELETE',
       })
         .then(() => {
-          toast.error(currentPlan.name + ' deleted!');
+          toast.error(currentPlan.name + ' deleted!', {
+            toastId: 'plan deleted'
+          });
           let updatedList = [...planList];
           updatedList = updatedList.filter((plan) => {
             return plan._id !== currentPlan._id;
@@ -51,7 +53,9 @@ const DeletePlanPopup: FC = () => {
         await userService.removeReview(review._id);
       });
     } else {
-      toast.error('Cannot delete last plan!');
+      toast.error('Cannot delete last plan!', {
+        toastId: 'cannot delete last plan'
+      });
     }
   };
 

--- a/lib/components/popups/DeletePlanPopup.tsx
+++ b/lib/components/popups/DeletePlanPopup.tsx
@@ -36,7 +36,7 @@ const DeletePlanPopup: FC = () => {
       })
         .then(() => {
           toast.error(currentPlan.name + ' deleted!', {
-            toastId: 'plan deleted'
+            toastId: 'plan deleted',
           });
           let updatedList = [...planList];
           updatedList = updatedList.filter((plan) => {
@@ -54,7 +54,7 @@ const DeletePlanPopup: FC = () => {
       });
     } else {
       toast.error('Cannot delete last plan!', {
-        toastId: 'cannot delete last plan'
+        toastId: 'cannot delete last plan',
       });
     }
   };

--- a/lib/components/popups/DeleteYearPopup.tsx
+++ b/lib/components/popups/DeleteYearPopup.tsx
@@ -40,12 +40,15 @@ const DeleteYearPopup: FC = () => {
           dispatch(updateSelectedPlan(newUpdatedPlan));
           dispatch(updateYearToDelete(null));
           dispatch(updateDeleteYearStatus(false));
-          toast.error('Deleted ' + year.name + '!');
+          toast.error('Deleted ' + year.name + '!', {
+            toastId: 'delete year'
+          });
         })
         .catch((err) => console.log(err));
     } else {
-      toast.error('Cannot delete last year!');
-    }
+      toast.error('Cannot delete last year!', {
+        toastId: 'cannot delete last year'
+      });    }
   };
 
   // Cancels plan delete

--- a/lib/components/popups/DeleteYearPopup.tsx
+++ b/lib/components/popups/DeleteYearPopup.tsx
@@ -41,14 +41,15 @@ const DeleteYearPopup: FC = () => {
           dispatch(updateYearToDelete(null));
           dispatch(updateDeleteYearStatus(false));
           toast.error('Deleted ' + year.name + '!', {
-            toastId: 'delete year'
+            toastId: 'delete year',
           });
         })
         .catch((err) => console.log(err));
     } else {
       toast.error('Cannot delete last year!', {
-        toastId: 'cannot delete last year'
-      });    }
+        toastId: 'cannot delete last year',
+      });
+    }
   };
 
   // Cancels plan delete

--- a/lib/components/popups/ExperimentDevBoardPopup.tsx
+++ b/lib/components/popups/ExperimentDevBoardPopup.tsx
@@ -158,6 +158,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Updated Experiments`, {
       autoClose: 5000,
       closeOnClick: false,
+      toastId: 'updated experiments'
     });
     setInputPercentages([...emptyArray]);
     setInputNames([...emptyArray]);
@@ -172,6 +173,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
         {
           autoClose: 5000,
           closeOnClick: false,
+          toastId: 'name already used'
         },
       );
       return;
@@ -187,6 +189,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Added Experiment ${inputName}`, {
       autoClose: 5000,
       closeOnClick: false,
+      toastId: 'added experiment'
     });
     setInputName('');
     setAddExperimentPopup(!addExperimentPopup);
@@ -202,6 +205,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Deleted Experiment`, {
       autoClose: 5000,
       closeOnClick: false,
+      toastId: 'delete experiment'
     });
     setNameExperimentToDelete('');
     setDeleteExperimentPopup(!deleteExperimentPopup);
@@ -288,6 +292,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
                             toast.success(`Copied ID to clipboard`, {
                               autoClose: 5000,
                               closeOnClick: true,
+                              toastId: 'copy ID'
                             });
                           }}
                         >

--- a/lib/components/popups/ExperimentDevBoardPopup.tsx
+++ b/lib/components/popups/ExperimentDevBoardPopup.tsx
@@ -158,7 +158,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Updated Experiments`, {
       autoClose: 5000,
       closeOnClick: false,
-      toastId: 'updated experiments'
+      toastId: 'updated experiments',
     });
     setInputPercentages([...emptyArray]);
     setInputNames([...emptyArray]);
@@ -173,7 +173,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
         {
           autoClose: 5000,
           closeOnClick: false,
-          toastId: 'name already used'
+          toastId: 'name already used',
         },
       );
       return;
@@ -189,7 +189,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Added Experiment ${inputName}`, {
       autoClose: 5000,
       closeOnClick: false,
-      toastId: 'added experiment'
+      toastId: 'added experiment',
     });
     setInputName('');
     setAddExperimentPopup(!addExperimentPopup);
@@ -205,7 +205,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
     toast.success(`Deleted Experiment`, {
       autoClose: 5000,
       closeOnClick: false,
-      toastId: 'delete experiment'
+      toastId: 'delete experiment',
     });
     setNameExperimentToDelete('');
     setDeleteExperimentPopup(!deleteExperimentPopup);
@@ -292,7 +292,7 @@ const ExperimentDevBoardPopup: FC<{}> = () => {
                             toast.success(`Copied ID to clipboard`, {
                               autoClose: 5000,
                               closeOnClick: true,
-                              toastId: 'copy ID'
+                              toastId: 'copy ID',
                             });
                           }}
                         >

--- a/lib/components/popups/PlanAdd.tsx
+++ b/lib/components/popups/PlanAdd.tsx
@@ -38,7 +38,7 @@ const PlanAdd: FC = () => {
   const createNewPlan = () => {
     if (toAddMajors.length === 0) {
       toast.error('Please choose a valid major!', {
-        toastId: 'choose valid major'
+        toastId: 'choose valid major',
       });
     } else {
       dispatch(updateAddingPlanStatus(false));
@@ -55,7 +55,7 @@ const PlanAdd: FC = () => {
   const handleCancel = () => {
     if (planList.length === 0) {
       toast.error('Please create at least one plan to continue!', {
-        toastId: 'create at least one plan'
+        toastId: 'create at least one plan',
       });
     } else {
       dispatch(updateAddingPlanStatus(false));

--- a/lib/components/popups/PlanAdd.tsx
+++ b/lib/components/popups/PlanAdd.tsx
@@ -37,7 +37,9 @@ const PlanAdd: FC = () => {
    */
   const createNewPlan = () => {
     if (toAddMajors.length === 0) {
-      toast.error('Please choose a valid major!');
+      toast.error('Please choose a valid major!', {
+        toastId: 'choose valid major'
+      });
     } else {
       dispatch(updateAddingPlanStatus(false));
       dispatch(updateGeneratePlanAddStatus(true));
@@ -52,7 +54,9 @@ const PlanAdd: FC = () => {
   // Handles user's intention to cancel creating a new plan.
   const handleCancel = () => {
     if (planList.length === 0) {
-      toast.error('Please create at least one plan to continue!');
+      toast.error('Please create at least one plan to continue!', {
+        toastId: 'create at least one plan'
+      });
     } else {
       dispatch(updateAddingPlanStatus(false));
     }

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -144,7 +144,9 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
     }
     dispatch(updatePlanList(newPlanList));
     dispatch(updateTotalCredits(totalCredits + newUserCourse.credits));
-    toast.success(version.title + ' added!');
+    toast.success(version.title + ' added!', {
+      toastId: 'title added'
+    });
   };
 
   if (version === 'None') {

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -145,7 +145,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
     dispatch(updatePlanList(newPlanList));
     dispatch(updateTotalCredits(totalCredits + newUserCourse.credits));
     toast.success(version.title + ' added!', {
-      toastId: 'title added'
+      toastId: 'title added',
     });
   };
 

--- a/lib/components/reviewer/PlanSummary.tsx
+++ b/lib/components/reviewer/PlanSummary.tsx
@@ -116,9 +116,12 @@ const PlanSummary: FC<{
       await userService.changeReviewStatus(review_id, value.toUpperCase());
       setRefreshReviews(true);
       setNotifState(false);
-      toast.success(`Status changed to ${statusReadable[value.toUpperCase()]}`, {
-        toastId: 'status updated'
-      });
+      toast.success(
+        `Status changed to ${statusReadable[value.toUpperCase()]}`,
+        {
+          toastId: 'status updated',
+        },
+      );
     } catch (e) {
       console.log(e);
     }

--- a/lib/components/reviewer/PlanSummary.tsx
+++ b/lib/components/reviewer/PlanSummary.tsx
@@ -116,7 +116,9 @@ const PlanSummary: FC<{
       await userService.changeReviewStatus(review_id, value.toUpperCase());
       setRefreshReviews(true);
       setNotifState(false);
-      toast.success(`Status changed to ${statusReadable[value.toUpperCase()]}`);
+      toast.success(`Status changed to ${statusReadable[value.toUpperCase()]}`, {
+        toastId: 'status updated'
+      });
     } catch (e) {
       console.log(e);
     }

--- a/lib/components/reviewer/Reviewee.tsx
+++ b/lib/components/reviewer/Reviewee.tsx
@@ -166,7 +166,9 @@ const Reviewee: React.FC<Props> = ({
                               `Status changed to ${
                                 statusReadable[value.label]
                               }`,
-                            );
+                            {
+                              toastId: 'status changed'
+                            });
                           } catch (e) {
                             console.log(e);
                           }

--- a/lib/components/reviewer/Reviewee.tsx
+++ b/lib/components/reviewer/Reviewee.tsx
@@ -166,9 +166,10 @@ const Reviewee: React.FC<Props> = ({
                               `Status changed to ${
                                 statusReadable[value.label]
                               }`,
-                            {
-                              toastId: 'status changed'
-                            });
+                              {
+                                toastId: 'status changed',
+                              },
+                            );
                           } catch (e) {
                             console.log(e);
                           }

--- a/lib/resources/GenerateNewPlan.tsx
+++ b/lib/resources/GenerateNewPlan.tsx
@@ -87,7 +87,9 @@ const GenerateNewPlan: FC = () => {
       // }
       dispatch(updateSelectedPlan(newPlan));
       dispatch(updatePlanList([newPlan, ...planList]));
-      if (!importing) toast.success(newPlan.name + ' created!');
+      if (!importing) toast.success(newPlan.name + ' created!', {
+        toastId: 'plan created'
+      });
       if (user._id === 'guestUser') {
         const planIdArray = [newPlan._id];
         dispatch(updateGuestPlanIds(planIdArray));

--- a/lib/resources/GenerateNewPlan.tsx
+++ b/lib/resources/GenerateNewPlan.tsx
@@ -87,9 +87,10 @@ const GenerateNewPlan: FC = () => {
       // }
       dispatch(updateSelectedPlan(newPlan));
       dispatch(updatePlanList([newPlan, ...planList]));
-      if (!importing) toast.success(newPlan.name + ' created!', {
-        toastId: 'plan created'
-      });
+      if (!importing)
+        toast.success(newPlan.name + ' created!', {
+          toastId: 'plan created',
+        });
       if (user._id === 'guestUser') {
         const planIdArray = [newPlan._id];
         dispatch(updateGuestPlanIds(planIdArray));

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -190,6 +190,7 @@ export type FilterType =
 
 export type AreaType = 'N' | 'S' | 'H' | 'W' | 'E' | 'Q';
 
+// Not useless, because Distributions and DistributionObj utilizes them
 export type FineReq = {
   required_credits: number;
   description: string;
@@ -197,6 +198,7 @@ export type FineReq = {
   double_count?: string[];
 };
 
+// Not useless, because used for major and minor
 export type DistributionObj = {
   name: string;
   required_credits: number;

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -190,7 +190,6 @@ export type FilterType =
 
 export type AreaType = 'N' | 'S' | 'H' | 'W' | 'E' | 'Q';
 
-// Not useless, because Distributions and DistributionObj utilizes them
 export type FineReq = {
   required_credits: number;
   description: string;
@@ -198,7 +197,6 @@ export type FineReq = {
   double_count?: string[];
 };
 
-// Not useless, because used for major and minor
 export type DistributionObj = {
   name: string;
   required_credits: number;

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -92,7 +92,7 @@ const Dash: React.FC = () => {
         if (router.query.plan) {
           router.push('/dashboard');
           toast.error('You do not have access to this plan!', {
-            toastId: 'cannot access plan'
+            toastId: 'cannot access plan',
           });
         }
       } catch (e) {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -91,7 +91,9 @@ const Dash: React.FC = () => {
         }
         if (router.query.plan) {
           router.push('/dashboard');
-          toast.error('You do not have access to this plan!');
+          toast.error('You do not have access to this plan!', {
+            toastId: 'cannot access plan'
+          });
         }
       } catch (e) {
         console.log(e);

--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -171,7 +171,9 @@ const Login: React.FC = () => {
    * Handles the case where we haven't logged in yet and users are exposed to the guest login button.
    */
   const preventPreLoginClick = () =>
-    toast.info("Please wait while we check if you're logged in...");
+    toast.info("Please wait while we check if you're logged in...", {
+      toastId: 'check login'
+    });
 
   /**
    * Handles custom session id change.

--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -172,7 +172,7 @@ const Login: React.FC = () => {
    */
   const preventPreLoginClick = () =>
     toast.info("Please wait while we check if you're logged in...", {
-      toastId: 'check login'
+      toastId: 'check login',
     });
 
   /**

--- a/pages/reviewer/[...id].tsx
+++ b/pages/reviewer/[...id].tsx
@@ -36,8 +36,12 @@ const ReviewerAdd: React.FC = () => {
         await userService.confirmReviewerPlan(
           reviewerPlanId,
           (status: number) => {
-            if (status === 400) toast.error('Failed');
-            else if (status === 200) toast.success('Confirmed reviewer plan!');
+            if (status === 400) toast.error('Failed', {
+              toastId: 'failed'
+            });
+            else if (status === 200) toast.success('Confirmed reviewer plan!', {
+              toastId: 'confirm reviewer plan'
+            });
           },
         );
         router.push('/reviewer');

--- a/pages/reviewer/[...id].tsx
+++ b/pages/reviewer/[...id].tsx
@@ -36,12 +36,14 @@ const ReviewerAdd: React.FC = () => {
         await userService.confirmReviewerPlan(
           reviewerPlanId,
           (status: number) => {
-            if (status === 400) toast.error('Failed', {
-              toastId: 'failed'
-            });
-            else if (status === 200) toast.success('Confirmed reviewer plan!', {
-              toastId: 'confirm reviewer plan'
-            });
+            if (status === 400)
+              toast.error('Failed', {
+                toastId: 'failed',
+              });
+            else if (status === 200)
+              toast.success('Confirmed reviewer plan!', {
+                toastId: 'confirm reviewer plan',
+              });
           },
         );
         router.push('/reviewer');


### PR DESCRIPTION
Currently when a user holds the delete button on the “Update Degrees” field, there are multiple “You must have at least one major!” popups that fill the screen for a few seconds. It is preferable to have one popup at a time.

As such, I created a toast ID for every unique toast.success(), toast.error(), toast.warn(), and toast.info() call. The toast container automatically ensures that two toast notifications with the same ID are not active at the same time. This solves the initial problem of having more than one "You must have at least one major!" popup when the user holds the delete button in the "Update Degrees" field.