### PR TITLE
DEV-59: squash bug with 2023 spring

### DIFF
--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -121,7 +121,7 @@ const YearComponent: FC<{
     let count: number = 0;
     courses.forEach((course) => {
       count += course.credits;
-      if (course.area !== 'None') {
+      if (course.area && course.area !== 'None') {
         for (let area of course.area) {
           switch (area) {
             case 'N':

--- a/lib/components/popups/course-search/query-components/Filters.tsx
+++ b/lib/components/popups/course-search/query-components/Filters.tsx
@@ -221,7 +221,7 @@ const Filters: FC<{
     if (yearRange) {
       let total = yearRange.max - yearRange.min + 1;
       if (new Date().getMonth() >= 3) total++;
-      const years: any= [];
+      const years: any = [];
       for (let i = 0; i < total; i++) {
         years.push({ value: yearRange.min + i, label: yearRange.min + i });
       }
@@ -249,7 +249,10 @@ const Filters: FC<{
           className="w-40 mx-1 rounded outline-none"
           onChange={handleYearFilterChange}
           value={{
-            value: searchFilters.term === "Spring" ? searchFilters.year + 1 : searchFilters.year,
+            value:
+              searchFilters.term === 'Spring'
+                ? searchFilters.year + 1
+                : searchFilters.year,
             label:
               searchFilters.year === currentPlan.years[0].year
                 ? 'All'

--- a/lib/components/popups/course-search/query-components/Filters.tsx
+++ b/lib/components/popups/course-search/query-components/Filters.tsx
@@ -10,6 +10,7 @@ import {
   updateSearchFilters,
 } from '../../../../slices/searchSlice';
 import { selectPlan } from '../../../../slices/currentPlanSlice';
+import React from 'react';
 
 const creditFilters = ['Any', 0, 1, 2, 3, 4];
 const distributionFilters = ['N', 'S', 'H', 'Q', 'E'];
@@ -218,9 +219,9 @@ const Filters: FC<{
   const getYears = (): { value: number; label: number }[] => {
     const yearRange = JSON.parse(localStorage.getItem('yearRange'));
     if (yearRange) {
-      let total = yearRange.max - yearRange.min;
+      let total = yearRange.max - yearRange.min + 1;
       if (new Date().getMonth() >= 3) total++;
-      const years = [];
+      const years: any= [];
       for (let i = 0; i < total; i++) {
         years.push({ value: yearRange.min + i, label: yearRange.min + i });
       }
@@ -248,7 +249,7 @@ const Filters: FC<{
           className="w-40 mx-1 rounded outline-none"
           onChange={handleYearFilterChange}
           value={{
-            value: searchFilters.year,
+            value: searchFilters.term === "Spring" ? searchFilters.year + 1 : searchFilters.year,
             label:
               searchFilters.year === currentPlan.years[0].year
                 ? 'All'

--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -117,7 +117,7 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
     // If the current year is the same as the year of the semester or later,
     // we need to check Fall, Spring, Intersession, and Summer to see if we need to increase year value.
     if (
-      (semester === 'Spring' && date.getMonth() >= 10) ||
+      (semester === 'Spring' && date.getMonth() >= 9) ||
       (semester === 'Intersession' && date.getMonth() === 11) ||
       (semester === 'Summer' &&
         date.getMonth() >= 2 &&


### PR DESCRIPTION
## issue 
added Spring 2023 courses into production db 
when trying to search for courses to add in spring 2023, searchFilter.year is still 2022 

## background 
in Form.tsx `handleFutureYear` function we determine the searchFilter.year depending on whether searchFilter.term is fall or spring. If term is spring and we are in October (when SIS courses are released), we want 2023 to be an option. 

## cause of bug
turns out getMonth() returns range [0,11] not [1,12]