### PR TITLE
DEV-59: fix bug with 2023 spring

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -118,10 +118,7 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
     // we need to check Fall, Spring, Intersession, and Summer to see if we need to increase year value.
     if (
       (semester === 'Spring' && date.getMonth() >= 9) ||
-      (semester === 'Intersession' && date.getMonth() === 11) ||
-      (semester === 'Summer' &&
-        date.getMonth() >= 2 &&
-        yearVal !== date.getFullYear())
+      (semester === 'Intersession' && date.getMonth() === 11)
     )
       dispatch(
         updateSearchFilters({ filter: 'year', value: date.getFullYear() + 1 }),

--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -117,7 +117,7 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
     // If the current year is the same as the year of the semester or later,
     // we need to check Fall, Spring, Intersession, and Summer to see if we need to increase year value.
     if (
-      (semester === 'Spring' && date.getMonth() >= 10) ||
+      (semester === 'Spring' && date.getMonth() >= 9) ||
       (semester === 'Intersession' && date.getMonth() === 11) ||
       (semester === 'Summer' &&
         date.getMonth() >= 2 &&


### PR DESCRIPTION
## issue 
added Spring 2023 courses into production db 
when trying to search for courses to add in spring 2023, searchFilter.year is still 2022 

## background 
in Form.tsx `handleFutureYear` function we determine the searchFilter.year depending on whether searchFilter.term is fall or spring. If term is spring and we are in October (when SIS courses are released), we want 2023 to be an option. 

see related PR in backend:[https://github.com/uCredit-Dev/uCredit-API/pull/53]( https://github.com/uCredit-Dev/uCredit-API/pull/53 )

UPDATE: noticed that when searching for courses in Summer 2023, version year is set as 2023 and returns no courses. It should be 2022 because summer courses are not yet released.

## cause of bug
turns out getMonth() returns range [0,11] not [1,12]