### PR TITLE
DEV-63 Reviewer tries to access reviewee's plan, toast error appears

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -81,13 +81,14 @@ const Dash: React.FC = () => {
           router.push('/dashboard');
           return;
         }
-        const reviewers = (await userService.getPlanReviewers(res.data._id))
-          .data[0];
-        if (Object.values(reviewers.reviewer_id).includes(user._id)) {
-          dispatch(updateSelectedPlan(res.data));
-          dispatch(updateReviewMode(ReviewMode.View));
-          setMode(ReviewMode.View);
-          return;
+        const reviewers = await userService.getPlanReviewers(res.data._id);
+        for (const reviewer of reviewers.data) {
+          if (Object.values(reviewer.reviewer_id).includes(user._id)) {
+            dispatch(updateSelectedPlan(res.data));
+            dispatch(updateReviewMode(ReviewMode.View));
+            setMode(ReviewMode.View);
+            return;
+          }
         }
         if (router.query.plan) {
           router.push('/dashboard');


### PR DESCRIPTION
### Description
Sometimes when a reviewer tries to access a reviewee's plan through the reviewer dashboard, the toast error "You do not have access to this plan!" appears. The cause of the issue was due to only checking reviewee's first reviewer instead of checking all reviewers.  

### Implementation
Added a for loop to increment through a reviewee's array of reviewers. 

### Testing
Tested locally. Logged in as jdeng25 (reviewer), tried accessing kyang53, mpark63, and adeo1's plans (reviewees). 