### PR TITLE
DEV-66: courses is imported plan should have Version

### DIFF
--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -342,7 +342,7 @@ const HandlePlanShareDummy = () => {
             area: course.area,
             preReq: course.preReq,
             level: course.level,
-            version: course.version, 
+            version: course.version,
             expireAt:
               user._id === 'guestUser'
                 ? Date.now() + 60 * 60 * 24 * 1000

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -342,6 +342,7 @@ const HandlePlanShareDummy = () => {
             area: course.area,
             preReq: course.preReq,
             level: course.level,
+            version: course.version, 
             expireAt:
               user._id === 'guestUser'
                 ? Date.now() + 60 * 60 * 24 * 1000


### PR DESCRIPTION
## bug 
inspecting course in imported plan crashes client-side 

## fix 
add version field to the POST api/courses call request body 

todo: add version to course documents lacking it 
update: todo is done 
[https://github.com/uCredit-Dev/uCredit-API/pull/55](https://github.com/uCredit-Dev/uCredit-API/pull/55 )