### PR TITLE
DEV-53 Toggling year menu when year is closed causes menu to immediately close when moving towards menu

### DIFF
--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -72,20 +72,7 @@ const Comments: FC<{
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        !expanded ||
-        // @ts-ignore: property does not exist error
-        (typeof e.target.className === 'string' &&
-          // @ts-ignore: property does not exist error
-          e.target.className.includes('option')) ||
-        // @ts-ignore: property does not exist error
-        e.target.tagName === 'svg' ||
-        // @ts-ignore: property does not exist error
-        e.target.tagName === 'path' ||
-        // @ts-ignore: property does not exist error
-        (e.target.tagName === 'DIV' && e.target.className.includes('css'))
-      )
-        return;
+      if (!expanded) return;
       const currentWrapperRef: any = wrapperRef.current;
       if (currentWrapperRef && !currentWrapperRef.contains(e.target))
         setExpanded(false);

--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -119,26 +119,6 @@ const YearComponent: FC<{
     return () => document.removeEventListener('click', handleClickOutside);
   }, [wrapperRef, display]);
 
-  // useEffect(() => {
-  //   const handleClickOutside = (e: MouseEvent) => {
-  //     const target = e.target as Element;
-  //     if (
-  //       !display ||
-  //       (typeof target.className === 'string' &&
-  //         target.className.includes('option')) ||
-  //       target.tagName === 'svg' ||
-  //       target.tagName === 'path' ||
-  //       (target.tagName === 'DIV' && target.className.includes('css'))
-  //     )
-  //       return;
-  //     const currentWrapperRef: any = wrapperRef.current;
-  //     if (currentWrapperRef && !currentWrapperRef.contains(e.target))
-  //       setDisplay(false);
-  //   };
-  //   document.addEventListener('click', handleClickOutside);
-  //   return () => document.removeEventListener('click', handleClickOutside);
-  // }, [wrapperRef, display]);
-
   /**
    * Updates the credit distribution of the year.
    */

--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -110,20 +110,7 @@ const YearComponent: FC<{
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        !display ||
-        // @ts-ignore: property does not exist error
-        (typeof e.target.className === 'string' &&
-          // @ts-ignore: property does not exist error
-          e.target.className.includes('option')) ||
-        // @ts-ignore: property does not exist error
-        e.target.tagName === 'svg' ||
-        // @ts-ignore: property does not exist error
-        e.target.tagName === 'path' ||
-        // @ts-ignore: property does not exist error
-        (e.target.tagName === 'DIV' && e.target.className.includes('css'))
-      )
-        return;
+      if (!display) return;
       const currentWrapperRef: any = wrapperRef.current;
       if (currentWrapperRef && !currentWrapperRef.contains(e.target))
         setDisplay(false);
@@ -131,6 +118,26 @@ const YearComponent: FC<{
     document.addEventListener('click', handleClickOutside);
     return () => document.removeEventListener('click', handleClickOutside);
   }, [wrapperRef, display]);
+
+  // useEffect(() => {
+  //   const handleClickOutside = (e: MouseEvent) => {
+  //     const target = e.target as Element;
+  //     if (
+  //       !display ||
+  //       (typeof target.className === 'string' &&
+  //         target.className.includes('option')) ||
+  //       target.tagName === 'svg' ||
+  //       target.tagName === 'path' ||
+  //       (target.tagName === 'DIV' && target.className.includes('css'))
+  //     )
+  //       return;
+  //     const currentWrapperRef: any = wrapperRef.current;
+  //     if (currentWrapperRef && !currentWrapperRef.contains(e.target))
+  //       setDisplay(false);
+  //   };
+  //   document.addEventListener('click', handleClickOutside);
+  //   return () => document.removeEventListener('click', handleClickOutside);
+  // }, [wrapperRef, display]);
 
   /**
    * Updates the credit distribution of the year.

--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -370,7 +370,9 @@ const YearComponent: FC<{
       )}
       onMouseLeave={() => {
         setDraggable(true);
-        setDisplay(false);
+        if (!collapse) {
+          setDisplay(false);
+        }
         setHovered(false);
       }}
       onMouseEnter={() => {

--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -108,6 +108,7 @@ const YearComponent: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [yearName]);
 
+  // if year is collapsed and user opens year settings dropdown, clicking outside the dropdown closes it
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (!display) return;

--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, FC } from 'react';
+import React, { useState, useEffect, useRef, FC } from 'react';
 import Semester from './Semester';
 import { ReviewMode, UserCourse, Year } from '../../../resources/commonTypes';
 import { DotsVerticalIcon } from '@heroicons/react/outline';
@@ -76,6 +76,8 @@ const YearComponent: FC<{
   const inspected = useSelector(selectInspectedCourse);
   const dispatch = useDispatch();
 
+  let wrapperRef = useRef(null);
+
   // Updates and parses all courses into semesters whenever the current plan or courses array changes.
   useEffect(() => {
     // For each of the user's courses for this year, put them in their respective semesters.
@@ -105,6 +107,30 @@ const YearComponent: FC<{
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [yearName]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        !display ||
+        // @ts-ignore: property does not exist error
+        (typeof e.target.className === 'string' &&
+          // @ts-ignore: property does not exist error
+          e.target.className.includes('option')) ||
+        // @ts-ignore: property does not exist error
+        e.target.tagName === 'svg' ||
+        // @ts-ignore: property does not exist error
+        e.target.tagName === 'path' ||
+        // @ts-ignore: property does not exist error
+        (e.target.tagName === 'DIV' && e.target.className.includes('css'))
+      )
+        return;
+      const currentWrapperRef: any = wrapperRef.current;
+      if (currentWrapperRef && !currentWrapperRef.contains(e.target))
+        setDisplay(false);
+    };
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [wrapperRef, display]);
 
   /**
    * Updates the credit distribution of the year.
@@ -512,16 +538,18 @@ const YearComponent: FC<{
             )}
           </div>
         </div>
-        {display && (
-          <YearSettingsDropdown
-            year={year}
-            setToShow={setToShow}
-            setDisplay={setDisplay}
-            toShow={toShow}
-            setEdittingName={setEdittingName}
-            id={id}
-          />
-        )}
+        <div ref={wrapperRef}>
+          {display && (
+            <YearSettingsDropdown
+              year={year}
+              setToShow={setToShow}
+              setDisplay={setDisplay}
+              toShow={toShow}
+              setEdittingName={setEdittingName}
+              id={id}
+            />
+          )}
+        </div>
       </div>
       {collapse ? (
         <div

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -217,7 +217,6 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
           distDoubleCount.includes('All')) &&
         checkRequirementSatisfied(req, courseObj)
       ) {
-        console.log(courseObj.title, req.name, distDoubleCount);
         // update credit only if credit requirement not met
         if (
           req.fulfilled_credits < req.required_credits ||


### PR DESCRIPTION
### Description
Toggling year menu when year is closed causes menu to immediately close when moving towards menu.

### Implementation
If a year is collapsed, when the user opens the year settings dropdown, clicking outside of the dropdown or clicking the three dots icon closes the dropdown. 

### Testing
Tested locally.

### Notes
I also refactored handleClickOutside in Comments.tsx. 