### PR TITLE
DEV-90: add key props to render of Laptop and DistributionJSX

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -92,24 +92,28 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       },
     );
     distributionJSX.unshift(
-      <CourseBar
-        distribution={{
-          name: 'Total Credits',
-          expr: '',
-          required_credits: major !== null ? major.total_degree_credit : 0,
-          fulfilled_credits: totalCredits,
-          description:
-            major !== null
-              ? 'This is the total amount of credits that is required for ' +
-                major.degree_name
-              : '',
-        }}
-        completed={
-          totalCredits >= (major !== null ? major.total_degree_credit : 0)
-        }
-        general={true}
-        bgcolor=""
-      />,
+      <div key={"total"}>
+        <div key={"total"+0+"total"}>
+          <CourseBar
+            distribution={{
+              name: 'Total Credits',
+              expr: '',
+              required_credits: major !== null ? major.total_degree_credit : 0,
+              fulfilled_credits: totalCredits,
+              description:
+                major !== null
+                  ? 'This is the total amount of credits that is required for ' +
+                    major.degree_name
+                  : '',
+            }}
+            completed={
+              totalCredits >= (major !== null ? major.total_degree_credit : 0)
+            }
+            general={true}
+            bgcolor=""
+          />
+        </div>
+      </div>
     );
     setDistributionBarsJSX(distributionJSX);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -92,8 +92,8 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
       },
     );
     distributionJSX.unshift(
-      <div key={"total"}>
-        <div key={"total"+0+"total"}>
+      <div key={'total'}>
+        <div key={'total' + 0 + 'total'}>
           <CourseBar
             distribution={{
               name: 'Total Credits',
@@ -113,7 +113,7 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
             bgcolor=""
           />
         </div>
-      </div>
+      </div>,
     );
     setDistributionBarsJSX(distributionJSX);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/components/popups/course-search/cart/CartCourseListItem.tsx
+++ b/lib/components/popups/course-search/cart/CartCourseListItem.tsx
@@ -57,7 +57,7 @@ const CartCourseListItem: FC<{
               props.course.terms.map((fullTerm) => fullTerm.split(' ')[0]),
             ),
           ].map((term) => (
-            <div className="ml-1">{term}</div>
+            <div key={term} className="ml-1">{term}</div>
           ))}
         </div>
       </div>

--- a/lib/components/popups/course-search/cart/CartCourseListItem.tsx
+++ b/lib/components/popups/course-search/cart/CartCourseListItem.tsx
@@ -57,7 +57,9 @@ const CartCourseListItem: FC<{
               props.course.terms.map((fullTerm) => fullTerm.split(' ')[0]),
             ),
           ].map((term) => (
-            <div key={term} className="ml-1">{term}</div>
+            <div key={term} className="ml-1">
+              {term}
+            </div>
           ))}
         </div>
       </div>

--- a/lib/components/popups/course-search/cart/FineRequirementsList.tsx
+++ b/lib/components/popups/course-search/cart/FineRequirementsList.tsx
@@ -18,7 +18,7 @@ const FineRequirementsList: FC<{
 
   const getRequirements = () => {
     return props.selectedDistribution[1].map((requirement, i) => {
-      if (i === 0) return <></>; // TODO : better key
+      if (i === 0) return <div key={0}></div>; // TODO : better key
       return (
         <div key={i}>
           <FineRequirementListItem

--- a/lib/components/roadmap/Banner.tsx
+++ b/lib/components/roadmap/Banner.tsx
@@ -73,7 +73,7 @@ const Laptop: React.FC = () => {
             {/*tagsList*/}
             <div className="flex flex-row ml-64 mt-2">
               {tags.map((tag) => (
-                <div>
+                <div key={tag}>
                   <button
                     key={tag}
                     className="flex-grow-0 mx-2 px-3 pt-0.5 pb-1 rounded-3xl text-blue bg-yellow-tag"


### PR DESCRIPTION
## warning in console 
Warning: Each child in a list should have a unique "key" prop error 
<img width="385" alt="Screen Shot 2022-11-20 at 1 07 39 AM" src="https://user-images.githubusercontent.com/90944895/202888492-b72c2ad4-c096-453c-902d-27069c961d25.png">
<img width="337" alt="Screen Shot 2022-11-20 at 1 07 27 AM" src="https://user-images.githubusercontent.com/90944895/202888493-5fc3f119-51e7-4359-8d88-8fdc6a15db12.png">

## fix 
add the key props in the render methods of Laptop and DistributionsJSX
warning disappears 