### PR TITLE
DEV-88 Unhandled runtime error when adding prereq course

### DIFF
--- a/lib/components/dashboard/degree-info/distributionFunctions.tsx
+++ b/lib/components/dashboard/degree-info/distributionFunctions.tsx
@@ -66,9 +66,13 @@ export const getBoolExpr = (
     } else {
       concat = handleTagType(splitArr, index, course);
     }
+    if (index === 0 && concat === '&&!') {
+      boolExpr = boolExpr.concat('true');
+    }
     if (concat.length > 3) {
       index = index + 2;
     } else index++;
+
     boolExpr = boolExpr.concat(concat); // Causing issues with biology major.
   }
   return boolExpr;


### PR DESCRIPTION
### Description
Sometimes there is an Unhandled Runtime Error upon adding a prereq course from the cart. 

### Implementation
In getBoolExpr in distributionFunctions.tsx, if the operator is NOT then '&&!' is concatenated to the expression. However, if NOT is first in the conditional statement, then there is no boolean before '&&', which causes an error. So the implementation checks if NOT is first in the condition, and if yes, concatenates 'true' before '&&!'.

### Testing
Tested locally. Tested with B.A. IS plan. Tracker -> Economics (Degree Progress) -> One other Economics Course (Fine Requirement) -> Microeconomic Theory (Search Result Course) -> Calculus I (Prereq)