### PR TITLE
DEV-22 - users can now remove pending reviewers

### DIFF
--- a/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
+++ b/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
@@ -25,8 +25,7 @@ const ReviewerSearchResults: FC<{
 
   const isReviewer = (id: string) => {
     for (const { reviewer_id, status, _id } of planReviewers) {
-      if (reviewer_id._id === id && status !== ReviewRequestStatus.Pending)
-        return _id;
+      if (reviewer_id._id === id) return _id;
     }
     return '';
   };

--- a/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
+++ b/lib/components/dashboard/menus/reviewers/ReviewerSearchResults.tsx
@@ -24,7 +24,7 @@ const ReviewerSearchResults: FC<{
   }, [currentPlan._id]);
 
   const isReviewer = (id: string) => {
-    for (const { reviewer_id, status, _id } of planReviewers) {
+    for (const { reviewer_id, _id } of planReviewers) {
       if (reviewer_id._id === id) return _id;
     }
     return '';


### PR DESCRIPTION
**Description**
Users cannot remove pending reviewers (reviewers who were requested but have not yet accepted the request).

**Implementation**
In the isReviewer function in ReviewerSearchResults.tsx, the function only returned the ID of a proposed reviewer if the status of that reviewer was not "pending." This implementation simply removed the check of the proposed reviewers' status, so now reviewers of all statuses (Approved, Rejected, Under Review, and Pending) can be removed.

**Testing**
Tested locally. Created a new account and added the actual account linked to my JHED as a reviewer. Then, I attempted to delete my reviewer and succeeded. To check that the process of adding reviewers wasn't affected by my code fix, I created a second dummy account and added myself as a review. I then proceeded to accept the request to ensure that the reviewer request process remained intact.