### PR TITLE
DEV-89: make guestUser documents expire after a day

### DIFF
--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -213,10 +213,7 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
       const body = {
         ...newYear,
         preUniversity: preUniversity,
-        expireAt:
-          user._id === 'guestUser'
-            ? Date.now()
-            : undefined,
+        expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       }; // add to end by default
       axios
         .post(getAPI(window) + '/years', body)

--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -215,7 +215,7 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
         preUniversity: preUniversity,
         expireAt:
           user._id === 'guestUser'
-            ? Date.now() + 60 * 60 * 24 * 1000
+            ? Date.now()
             : undefined,
       }; // add to end by default
       axios

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -194,7 +194,7 @@ const HandlePlanShareDummy = () => {
         preUniversity: false,
         expireAt:
           user._id === 'guestUser'
-            ? Date.now() + 60 * 60 * 24 * 1000
+            ? Date.now()
             : undefined,
       }; // add to end by default
       const postYearResp: any = await axios
@@ -345,7 +345,7 @@ const HandlePlanShareDummy = () => {
             version: course.version,
             expireAt:
               user._id === 'guestUser'
-                ? Date.now() + 60 * 60 * 24 * 1000
+                ? Date.now()
                 : undefined,
           };
           fetch(getAPI(window) + '/courses', {

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -192,10 +192,7 @@ const HandlePlanShareDummy = () => {
       const body = {
         ...yearBody,
         preUniversity: false,
-        expireAt:
-          user._id === 'guestUser'
-            ? Date.now()
-            : undefined,
+        expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       }; // add to end by default
       const postYearResp: any = await axios
         .post(getAPI(window) + '/years', body)
@@ -343,10 +340,7 @@ const HandlePlanShareDummy = () => {
             preReq: course.preReq,
             level: course.level,
             version: course.version,
-            expireAt:
-              user._id === 'guestUser'
-                ? Date.now()
-                : undefined,
+            expireAt: user._id === 'guestUser' ? Date.now() : undefined,
           };
           fetch(getAPI(window) + '/courses', {
             method: 'POST',

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -207,10 +207,7 @@ const Semester: FC<{
         isPlaceholder: placeholder,
         area: inspectedArea,
         version: semesterName + ' ' + semesterYear.year,
-        expireAt:
-          user._id === 'guestUser'
-            ? Date.now()
-            : undefined,
+        expireAt: user._id === 'guestUser' ? Date.now() : undefined,
         _id: undefined,
       };
 

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -209,7 +209,7 @@ const Semester: FC<{
         version: semesterName + ' ' + semesterYear.year,
         expireAt:
           user._id === 'guestUser'
-            ? Date.now() + 60 * 60 * 24 * 1000
+            ? Date.now()
             : undefined,
         _id: undefined,
       };

--- a/lib/components/dashboard/menus/PlanEditMenu.tsx
+++ b/lib/components/dashboard/menus/PlanEditMenu.tsx
@@ -213,7 +213,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
         preUniversity: preUniversity,
         expireAt:
           user._id === 'guestUser'
-            ? Date.now() + 60 * 60 * 24 * 1000
+            ? Date.now()
             : undefined,
       }; // add to end by default
       axios

--- a/lib/components/dashboard/menus/PlanEditMenu.tsx
+++ b/lib/components/dashboard/menus/PlanEditMenu.tsx
@@ -211,10 +211,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
       const body = {
         ...newYear,
         preUniversity: preUniversity,
-        expireAt:
-          user._id === 'guestUser'
-            ? Date.now()
-            : undefined,
+        expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       }; // add to end by default
       axios
         .post(getAPI(window) + '/years', body)

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -151,7 +151,7 @@ const CourseDisplayPopup: FC = () => {
         level: version.level,
         expireAt:
           user._id === 'guestUser'
-            ? Date.now() + 60 * 60 * 24 * 1000
+            ? Date.now()
             : undefined,
       };
       fetch(getAPI(window) + '/courses', {

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -149,10 +149,7 @@ const CourseDisplayPopup: FC = () => {
         wi: version.wi,
         version: version.term,
         level: version.level,
-        expireAt:
-          user._id === 'guestUser'
-            ? Date.now()
-            : undefined,
+        expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       };
       fetch(getAPI(window) + '/courses', {
         method: 'POST',

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -103,8 +103,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
       wi: version.wi,
       version: version.term,
       level: version.level,
-      expireAt:
-        user._id === 'guestUser' ? Date.now() : undefined,
+      expireAt: user._id === 'guestUser' ? Date.now() : undefined,
     };
 
     let retrieved = await fetch(getAPI(window) + '/courses', {

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -104,7 +104,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
       version: version.term,
       level: version.level,
       expireAt:
-        user._id === 'guestUser' ? Date.now() + 60 * 60 * 24 * 1000 : undefined,
+        user._id === 'guestUser' ? Date.now() : undefined,
     };
 
     let retrieved = await fetch(getAPI(window) + '/courses', {

--- a/lib/resources/GenerateNewPlan.tsx
+++ b/lib/resources/GenerateNewPlan.tsx
@@ -46,8 +46,7 @@ const GenerateNewPlan: FC = () => {
       user_id: user._id,
       majors: toAddMajors.map((major) => major.degree_name),
       year: user.grade,
-      expireAt:
-        user._id === 'guestUser' ? Date.now() : undefined,
+      expireAt: user._id === 'guestUser' ? Date.now() : undefined,
     };
     planBody.name = !importing ? toAddName : 'Imported ' + toAddName;
     dispatch(updateImportID(''));

--- a/lib/resources/GenerateNewPlan.tsx
+++ b/lib/resources/GenerateNewPlan.tsx
@@ -47,7 +47,7 @@ const GenerateNewPlan: FC = () => {
       majors: toAddMajors.map((major) => major.degree_name),
       year: user.grade,
       expireAt:
-        user._id === 'guestUser' ? Date.now() + 60 * 60 * 24 * 1000 : undefined,
+        user._id === 'guestUser' ? Date.now() : undefined,
     };
     planBody.name = !importing ? toAddName : 'Imported ' + toAddName;
     dispatch(updateImportID(''));
@@ -116,7 +116,7 @@ const GenerateNewPlan: FC = () => {
 //     plan_id: planID,
 //     filter: '',
 //     expireAt:
-//       userID === 'guestUser' ? Date.now() + 60 * 60 * 24 * 1000 : undefined,
+//       userID === 'guestUser' ? Date.now() : undefined,
 //   };
 // };
 


### PR DESCRIPTION
## problem 
too many outdated guestUser documents in db that slow our db queries  

## goal
The course, distribution, plan, and year documents **belonging to guestUser** should expire 24 hours after their creation. 

## implementation
The expireAt field is now a [TTL index](https://www.mongodb.com/docs/manual/core/index-ttl/). 
therefore, whenever we set the value of expireAt in frontend, it should be `Date.now()` or undefined 

### see: https://github.com/uCredit-Dev/uCredit-API/pull/65 