### PR TITLE
DEV-96: disable JHU login button and add popup on hover - dev

### DIFF
--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -191,8 +191,7 @@ const Login: React.FC = () => {
     handleJHULogin(session);
   };
 
-  const tooltip = 
-        `<ReactTooltip id="godTip" place="top" effect="solid">
+  const tooltip = `<ReactTooltip id="godTip" place="top" effect="solid">
           <div style="overflow: wrap; margin-bottom: 1rem;">uCredit JHU login is currently unavailable.</div>
           <div>Sorry, it will be back soon! In the meantime, please continue as guest.</div>
         </ReactTooltip>`;

--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -22,6 +22,7 @@ import { User } from '../../lib/resources/commonTypes';
 import { userService } from '../../lib/services';
 import { updateAddingPlanStatus } from '../../lib/slices/popupSlice';
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 
 /**
  * The login page, designed after the Spotify login page..
@@ -190,6 +191,12 @@ const Login: React.FC = () => {
     handleJHULogin(session);
   };
 
+  const tooltip = 
+        `<ReactTooltip id="godTip" place="top" effect="solid">
+          <div style="overflow: wrap; margin-bottom: 1rem;">uCredit JHU login is currently unavailable.</div>
+          <div>Sorry, it will be back soon! In the meantime, please continue as guest.</div>
+        </ReactTooltip>`;
+
   return (
     <>
       <Head>
@@ -259,12 +266,18 @@ const Login: React.FC = () => {
               <div className="w-full mx-auto mt-8 text-4xl text-center mb-14">
                 Quick accessible degree planning.
               </div>
-              <button
-                onClick={handleJHULogin}
-                className="flex flex-row items-center justify-center w-64 h-12 mx-auto font-semibold tracking-widest transition duration-200 ease-in transform rounded-full cursor-pointer select-none bg-secondary hover:scale-105"
+              <div
+                data-tip={tooltip}
+                data-for="godTip"
+                onMouseOver={() => ReactTooltip.rebuild()}
               >
-                JHU Login
-              </button>
+                <button
+                  // onClick={handleJHULogin}
+                  className="flex flex-row items-center justify-center w-64 h-12 mx-auto font-semibold tracking-widest transition duration-200 ease-in transform rounded-full cursor-pointer select-none bg-gray-400 hover:scale-105"
+                >
+                  JHU Login
+                </button>
+              </div>
               <button
                 className="flex flex-row items-center justify-center w-64 h-12 mx-auto mt-5 mb-auto font-semibold tracking-widest transition duration-200 ease-in transform rounded-full cursor-pointer select-none bg-secondary focus:outline-none hover:scale-105"
                 onClick={


### PR DESCRIPTION
## Problem
Heroku API deployment will be offline starting tomorrow.
Render can handle all routes except for the **JHU login route**. So JHU login feature will be unavailable until IT whitelists our new API link. Sorry for the delay in getting it whitelisted with JHU SSO! Hopefully it should be done by Tuesday. 11/29 

## Temporary changes
- disable JHU login button 
- show maintenance popup on hover 

Note that if the user has a valid connect.sid cookie (hash value), the frontend will automatically attempt to log them in using sessions DB login. Otherwise, they will have to continue as guest. 

We will merge this PR at November 28th 1AM. 
We will revert this commit whenever render deployment gets whitelisted.