### PR TITLE
DEV-44: search result pagination 

### DIFF
--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -4,7 +4,7 @@ import { useCookies } from 'react-cookie';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 import { getAPI, guestUser } from '../../resources/assets';
-import { Plan, UserCourse, Year } from '../../resources/commonTypes';
+import { Plan, SISRetrievedCourse, UserCourse, Year } from '../../resources/commonTypes';
 import { getMajorFromCommonName } from '../../resources/majors';
 import {
   selectCurrentPlanCourses,
@@ -83,9 +83,9 @@ const HandlePlanShareDummy = () => {
       .catch((e) => {
         console.log('ERROR: ', e);
       });
-    let years = yearsResponse.data.data;
 
-    cache(years);
+    cache(id);
+    let years = yearsResponse.data.data;
     // check whether the user is logged in (whether a cookie exists)
     let cookieVal = '';
     Object.entries(cookies).forEach((cookie: any) => {
@@ -126,28 +126,17 @@ const HandlePlanShareDummy = () => {
    * Caches all courses in plans
    * @param years - an array of years of the plan
    */
-  const cache = (years: Year[]) => {
-    let total = 0;
-    let cum = 0;
-    years.forEach((y) => {
-      if (cum === total) {
-        setCached(true);
-      }
-      y.courses.forEach((c) => {
-        total++;
-        axios
-          .get(getAPI(window) + '/search', {
-            params: { query: c._id },
-          })
-          .then((retrieved) => {
-            dispatch(updateCourseCache(retrieved.data.data));
-            cum++;
-            if (cum === total) {
-              setCached(true);
-            }
-          });
+  const cache = (id: string) => {
+    axios
+      .get(getAPI(window) + '/coursesByPlan/' + id)
+      .then((response) => {
+        const sisCourses: SISRetrievedCourse[] = response.data.data; 
+        dispatch(updateCourseCache(sisCourses));
+      })
+      .catch((err) => {
+        console.log(err);
       });
-    });
+    setCached(true);
   };
 
   // Imports or creates new plan.

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -4,7 +4,12 @@ import { useCookies } from 'react-cookie';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-toastify';
 import { getAPI, guestUser } from '../../resources/assets';
-import { Plan, SISRetrievedCourse, UserCourse, Year } from '../../resources/commonTypes';
+import {
+  Plan,
+  SISRetrievedCourse,
+  UserCourse,
+  Year,
+} from '../../resources/commonTypes';
 import { getMajorFromCommonName } from '../../resources/majors';
 import {
   selectCurrentPlanCourses,
@@ -130,7 +135,7 @@ const HandlePlanShareDummy = () => {
     axios
       .get(getAPI(window) + '/coursesByPlan/' + id)
       .then((response) => {
-        const sisCourses: SISRetrievedCourse[] = response.data.data; 
+        const sisCourses: SISRetrievedCourse[] = response.data.data;
         dispatch(updateCourseCache(sisCourses));
       })
       .catch((err) => {

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -54,13 +54,13 @@ const HandlePlanShareDummy = () => {
 
   useEffect(() => {
     if (id !== null) {
-      handleExistingUser();
+      handleExistingUser(id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Handle the case where the user is already exists
-  const handleExistingUser = async (): Promise<void> => {
+  const handleExistingUser = async (id: string): Promise<void> => {
     const planResponse: any = await axios
       .get(getAPI(window) + '/plans/' + id, {
         headers: { Authorization: `Bearer ${token}` },
@@ -129,7 +129,7 @@ const HandlePlanShareDummy = () => {
 
   /**
    * Caches all courses in plans
-   * @param years - an array of years of the plan
+   * @param id - plan id
    */
   const cache = (id: string) => {
     axios

--- a/lib/components/dashboard/HandlePlanShareDummy.tsx
+++ b/lib/components/dashboard/HandlePlanShareDummy.tsx
@@ -133,7 +133,11 @@ const HandlePlanShareDummy = () => {
    */
   const cache = (id: string) => {
     axios
-      .get(getAPI(window) + '/coursesByPlan/' + id)
+      .get(getAPI(window) + '/coursesByPlan/' + id, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
       .then((response) => {
         const sisCourses: SISRetrievedCourse[] = response.data.data;
         dispatch(updateCourseCache(sisCourses));

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -235,6 +235,7 @@ const CourseList: FC<Props> = ({ mode }) => {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
       },
       body: JSON.stringify(body),
     });

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -231,25 +231,24 @@ const CourseList: FC<Props> = ({ mode }) => {
       newTerm: destination.semester,
     };
 
-    let res: any = 
-      await fetch(getAPI(window) + '/courses/dragged', {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      });
+    let res: any = await fetch(getAPI(window) + '/courses/dragged', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
 
-    // handle error 
+    // handle error
     if (!res.ok) {
       if (res.status === 400) {
         toast.error("Course isn't usually held this semester!", {
           toastId: 'no course this semester',
-        });    
+        });
       }
       console.log('ERROR:', res);
-      return; 
-    } 
+      return;
+    }
 
     toast.success('Successfully moved course!', {
       toastId: 'moved course',

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -235,7 +235,7 @@ const CourseList: FC<Props> = ({ mode }) => {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(body),
     });

--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -6,11 +6,9 @@ import {
   Plan,
   ReviewMode,
   SemesterType,
-  SISRetrievedCourse,
   UserCourse,
   Year,
 } from '../../../resources/commonTypes';
-import axios from 'axios';
 import {
   selectCurrentPlanCourses,
   selectDroppables,
@@ -27,7 +25,6 @@ import { toast } from 'react-toastify';
 import {
   selectPlanList,
   selectToken,
-  updateCourseCache,
   updatePlanList,
 } from '../../../slices/userSlice';
 import { getAPI } from '../../../resources/assets';
@@ -227,105 +224,68 @@ const CourseList: FC<Props> = ({ mode }) => {
     const courseYearIndex: number = sourceYear.courses
       .map((c) => c._id)
       .indexOf(course._id);
-    try {
-      const resp = await axios.get(getAPI(window) + '/search', {
-        params: { query: course.number },
+    const body = {
+      newYear: destYear._id,
+      oldYear: sourceYear._id,
+      courseId: course._id,
+      newTerm: destination.semester,
+    };
+
+    let res: any = 
+      await fetch(getAPI(window) + '/courses/dragged', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
       });
-      let retrievedCourses: SISRetrievedCourse[] = resp.data.data;
-      dispatch(updateCourseCache(retrievedCourses));
-      if (
-        retrievedCourses.length !== 0 &&
-        !checkDestValid(course, destination, retrievedCourses)
-      ) {
+
+    // handle error 
+    if (!res.ok) {
+      if (res.status === 400) {
         toast.error("Course isn't usually held this semester!", {
           toastId: 'no course this semester',
-        });
-      } else {
-        const body = {
-          newYear: destYear._id,
-          oldYear: sourceYear._id,
-          courseId: course._id,
-          newTerm: destination.semester,
-        };
-
-        let res: any = await fetch(getAPI(window) + '/courses/dragged', {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify(body),
-        });
-
-        if (!res.ok) {
-          console.log('ERROR:', res);
-        } else {
-          toast.success('Successfully moved course!', {
-            toastId: 'moved course',
-          });
-        }
-        res = await res.json();
-        const updatedCourse = res.data;
-
-        const sourceCourseArr = [...sourceYear.courses];
-        let destCourseArr = [...destYear.courses];
-        sourceCourseArr.splice(courseYearIndex, 1);
-        if (destCourseArr.map((c) => c._id).indexOf(updatedCourse._id) === -1) {
-          destCourseArr.push(updatedCourse);
-        } else {
-          // otherwase source and destination are the same.
-          destCourseArr = sourceCourseArr;
-          destCourseArr.push(updatedCourse);
-        }
-        const currPlanYears = [...currentPlan.years];
-        currPlanYears[sourceObj.index] = {
-          ...sourceYear,
-          courses: sourceCourseArr,
-        };
-        currPlanYears[destObj.index] = {
-          ...destYear,
-          courses: destCourseArr,
-        };
-
-        const newCurrentPlan: Plan = {
-          ...currentPlan,
-          years: currPlanYears,
-        };
-        const planListClone = [...planList];
-        planListClone[0] = newCurrentPlan;
-        updatePlanCourses(destYear, destination.semester, updatedCourse);
-        dispatch(updatePlanList(planListClone));
-        dispatch(updateSelectedPlan(newCurrentPlan));
+        });    
       }
-    } catch (err) {
-      console.log('error is: ' + err);
-    }
-  };
+      console.log('ERROR:', res);
+      return; 
+    } 
 
-  /**
-   * Checks if droppable destination is valid
-   * @param courseId - course id of course you are dragging
-   * @param dest - destination droppable
-   * @returns true if valid destination, false if not
-   */
-  const checkDestValid = (
-    course: UserCourse,
-    dest: DroppableType,
-    retrievedCourses: SISRetrievedCourse[],
-  ): boolean => {
-    let valid = false;
-    for (let sisVer of retrievedCourses) {
-      if (valid) break;
-      if (sisVer.number === course.number) {
-        for (let term of sisVer.terms) {
-          if (term.split(' ')[0] === dest.semester) {
-            valid = true;
-            break;
-          }
-        }
-      }
+    toast.success('Successfully moved course!', {
+      toastId: 'moved course',
+    });
+    res = await res.json();
+    const updatedCourse = res.data;
+
+    const sourceCourseArr = [...sourceYear.courses];
+    let destCourseArr = [...destYear.courses];
+    sourceCourseArr.splice(courseYearIndex, 1);
+    if (destCourseArr.map((c) => c._id).indexOf(updatedCourse._id) === -1) {
+      destCourseArr.push(updatedCourse);
+    } else {
+      // otherwase source and destination are the same.
+      destCourseArr = sourceCourseArr;
+      destCourseArr.push(updatedCourse);
     }
-    return valid;
+    const currPlanYears = [...currentPlan.years];
+    currPlanYears[sourceObj.index] = {
+      ...sourceYear,
+      courses: sourceCourseArr,
+    };
+    currPlanYears[destObj.index] = {
+      ...destYear,
+      courses: destCourseArr,
+    };
+
+    const newCurrentPlan: Plan = {
+      ...currentPlan,
+      years: currPlanYears,
+    };
+    const planListClone = [...planList];
+    planListClone[0] = newCurrentPlan;
+    updatePlanCourses(destYear, destination.semester, updatedCourse);
+    dispatch(updatePlanList(planListClone));
+    dispatch(updateSelectedPlan(newCurrentPlan));
   };
 
   /**

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -89,7 +89,7 @@ const Semester: FC<{
 
   // Every time any courses within this semester changes, update total credit count and the list.
   useEffect(() => {
-    if (version !== 'None') {
+    if (version !== 'None' && version.areas) {
       setInspectedArea(version.areas.charAt(0));
     }
     const sortedCourses: UserCourse[] = [...courses];

--- a/lib/components/dashboard/index.tsx
+++ b/lib/components/dashboard/index.tsx
@@ -168,7 +168,11 @@ const Dashboard: React.FC<Props> = ({ mode }) => {
     let source = axios.CancelToken.source();
     if (currPlan && currPlan._id !== 'noPlan') {
       axios
-        .get(getAPI(window) + '/coursesByPlan/' + currPlan._id)
+        .get(getAPI(window) + `/coursesByPlan/${currPlan._id}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },  
+        })
         .then((response) => {
           const sisCourses: SISRetrievedCourse[] = response.data.data;
           dispatch(updateCourseCache(sisCourses));

--- a/lib/components/dashboard/index.tsx
+++ b/lib/components/dashboard/index.tsx
@@ -51,7 +51,11 @@ import GenerateNewPlan from '../../resources/GenerateNewPlan';
 import LoadingPage from '../LoadingPage';
 import HandlePlanShareDummy from './HandlePlanShareDummy';
 import HandleUserInfoSetupDummy from './HandleUserInfoSetupDummy';
-import { DashboardMode, ReviewMode, SISRetrievedCourse } from '../../resources/commonTypes';
+import {
+  DashboardMode,
+  ReviewMode,
+  SISRetrievedCourse,
+} from '../../resources/commonTypes';
 import { userService } from '../../services';
 import Actionbar from './Actionbar';
 import Button from '@mui/material/Button';
@@ -166,7 +170,7 @@ const Dashboard: React.FC<Props> = ({ mode }) => {
       axios
         .get(getAPI(window) + '/coursesByPlan/' + currPlan._id)
         .then((response) => {
-          const sisCourses: SISRetrievedCourse[] = response.data.data; 
+          const sisCourses: SISRetrievedCourse[] = response.data.data;
           dispatch(updateCourseCache(sisCourses));
           console.log(sisCourses);
         })

--- a/lib/components/dashboard/index.tsx
+++ b/lib/components/dashboard/index.tsx
@@ -42,6 +42,7 @@ import {
   selectToken,
   selectUser,
   updateCommenters,
+  updateCourseCache,
 } from '../../slices/userSlice';
 import axios from 'axios';
 import { getAPI } from './../../resources/assets';
@@ -50,7 +51,7 @@ import GenerateNewPlan from '../../resources/GenerateNewPlan';
 import LoadingPage from '../LoadingPage';
 import HandlePlanShareDummy from './HandlePlanShareDummy';
 import HandleUserInfoSetupDummy from './HandleUserInfoSetupDummy';
-import { DashboardMode, ReviewMode } from '../../resources/commonTypes';
+import { DashboardMode, ReviewMode, SISRetrievedCourse } from '../../resources/commonTypes';
 import { userService } from '../../services';
 import Actionbar from './Actionbar';
 import Button from '@mui/material/Button';
@@ -162,6 +163,16 @@ const Dashboard: React.FC<Props> = ({ mode }) => {
     let unmounted = false;
     let source = axios.CancelToken.source();
     if (currPlan && currPlan._id !== 'noPlan') {
+      axios
+        .get(getAPI(window) + '/coursesByPlan/' + currPlan._id)
+        .then((response) => {
+          const sisCourses: SISRetrievedCourse[] = response.data.data; 
+          dispatch(updateCourseCache(sisCourses));
+          console.log(sisCourses);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
       userService
         .getThreads(currPlan._id, token, unmounted, source.token)
         .then((res) => {

--- a/lib/components/dashboard/index.tsx
+++ b/lib/components/dashboard/index.tsx
@@ -171,7 +171,7 @@ const Dashboard: React.FC<Props> = ({ mode }) => {
         .get(getAPI(window) + `/coursesByPlan/${currPlan._id}`, {
           headers: {
             Authorization: `Bearer ${token}`,
-          },  
+          },
         })
         .then((response) => {
           const sisCourses: SISRetrievedCourse[] = response.data.data;

--- a/lib/components/dashboard/index.tsx
+++ b/lib/components/dashboard/index.tsx
@@ -172,7 +172,6 @@ const Dashboard: React.FC<Props> = ({ mode }) => {
         .then((response) => {
           const sisCourses: SISRetrievedCourse[] = response.data.data;
           dispatch(updateCourseCache(sisCourses));
-          console.log(sisCourses);
         })
         .catch((err) => {
           console.log(err);

--- a/lib/components/popups/course-search/Cart.tsx
+++ b/lib/components/popups/course-search/Cart.tsx
@@ -23,7 +23,7 @@ import {
   updateRetrievedCourses,
 } from '../../../slices/searchSlice';
 import axios from 'axios';
-import { getAPI } from '../../../resources/assets';
+import { getAPI, getParams } from '../../../resources/assets';
 import {
   selectCurrentPlanCourses,
   selectSelectedDistribution,
@@ -123,6 +123,7 @@ const Cart: FC<{ allCourses: SISRetrievedCourse[] }> = (props) => {
     index: number,
   ): SearchExtras => {
     let extras: SearchExtras = {
+      page: null,
       query: '',
       credits: null,
       areas: null,
@@ -148,7 +149,6 @@ const Cart: FC<{ allCourses: SISRetrievedCourse[] }> = (props) => {
         break;
       case 'N': // Name
         extras.query = splitArr[index];
-
         break;
       case 'W': //Written intensive
         extras.wi = true; // does this work?
@@ -169,63 +169,16 @@ const Cart: FC<{ allCourses: SISRetrievedCourse[] }> = (props) => {
     extras: SearchExtras,
   ): Promise<[SISRetrievedCourse[], number[]]> => {
     return new Promise(async (resolve) => {
-      // let courses: SISRetrievedCourse[] = [...courseCache]; // how actively is this cache updated?
-      // if (!retrievedAll) { // how often is this filter used?
       const retrieved: any = await axios
-        .get(getAPI(window) + '/search', {
+        .get(getAPI(window) + '/cartSearch', {
           params: getParams(extras),
         })
         .catch(() => {
           return [[], []];
         });
-      let SISRetrieved: SISRetrievedCourse[] = processedRetrievedData(
-        retrieved.data.data,
-        extras,
-      );
-      return resolve([SISRetrieved, []]);
-      // } else {
-      //   const filterProcessing = filterCourses(extras, courses);
-      //   if (filterProcessing) return filterProcessing;
-      //   return resolve([courses, []]);
-      // }
+      return resolve([retrieved.data.data, []]);
     });
   };
-
-  const processedRetrievedData = (
-    data: SISRetrievedCourse[],
-    extras: SearchExtras,
-  ): SISRetrievedCourse[] => {
-    let SISRetrieved: SISRetrievedCourse[] = data;
-    if (extras.areas === 'N')
-      // TODO: backend searches for courses with "None" area. Fix this.
-      SISRetrieved = SISRetrieved.filter((course) => {
-        for (let version of course.versions) {
-          if (version.areas === 'N') return true;
-        }
-        return false;
-      });
-    // need some logic here to make sure all the courses are finished being found? since we're running
-    // multiple finds.
-    // if (
-    //   extras.query.length <= minLength ||
-    //   searchTerm.length - extras.query.length >= 2
-    // ) {
-    //   props.setSearching(false);
-    // }
-    return SISRetrieved;
-  };
-
-  // TODO : this is copied from Form.tsx. refactor inthe future
-  const getParams = (extras: SearchExtras) => ({
-    query: extras.query,
-    department: extras.department,
-    term: extras.term === 'All' ? '' : extras.term,
-    areas: extras.areas,
-    credits: extras.credits,
-    wi: extras.wi,
-    tags: extras.tags,
-    level: extras.levels,
-  });
 
   // for text filter
   const updateTextFilterInputValue = (

--- a/lib/components/popups/course-search/Search.tsx
+++ b/lib/components/popups/course-search/Search.tsx
@@ -6,6 +6,9 @@ import {
   updateSearchStatus,
   selectInspectedCourse,
   selectPlaceholder,
+  updatePageCount,
+  selectPageIndex,
+  updatePageIndex,
 } from '../../../slices/searchSlice';
 import CourseDisplay from './search-results/CourseDisplay';
 import Form from './query-components/Form';
@@ -35,6 +38,7 @@ const Search: FC = () => {
   const inspected = useSelector(selectInspectedCourse);
   const placeholder = useSelector(selectPlaceholder);
   const infoPopup = useSelector(selectInfoPopup);
+  const pageIndex = useSelector(selectPageIndex);
 
   /**
    * Gets specific year's name.
@@ -49,6 +53,14 @@ const Search: FC = () => {
     });
     return name;
   };
+
+  const setPageCount = (newPageCount: number) => {
+    dispatch(updatePageCount(newPageCount)); 
+  }
+
+  const setPageIndex = (newPageIndex: number) => {
+    dispatch(updatePageIndex(newPageIndex)); 
+  }
 
   useEffect(() => {
     if (inspected === 'None' && !placeholder) setHideResults(false);
@@ -90,11 +102,12 @@ const Search: FC = () => {
             <div className="h-full overflow-y-auto">
               {!hideResults && (
                 <>
-                  <Form setSearching={setSearching} />
+                  <Form setSearching={setSearching} pageIndex={pageIndex} setPageCount={setPageCount} setPageIndex={setPageIndex} />
                   <SearchList
                     searching={searching}
                     hideResults={hideResults}
                     setHideResults={setHideResults}
+                    setPageIndex={setPageIndex}
                   />
                 </>
               )}

--- a/lib/components/popups/course-search/Search.tsx
+++ b/lib/components/popups/course-search/Search.tsx
@@ -55,12 +55,12 @@ const Search: FC = () => {
   };
 
   const setPageCount = (newPageCount: number) => {
-    dispatch(updatePageCount(newPageCount)); 
-  }
+    dispatch(updatePageCount(newPageCount));
+  };
 
   const setPageIndex = (newPageIndex: number) => {
-    dispatch(updatePageIndex(newPageIndex)); 
-  }
+    dispatch(updatePageIndex(newPageIndex));
+  };
 
   useEffect(() => {
     if (inspected === 'None' && !placeholder) setHideResults(false);
@@ -102,7 +102,12 @@ const Search: FC = () => {
             <div className="h-full overflow-y-auto">
               {!hideResults && (
                 <>
-                  <Form setSearching={setSearching} pageIndex={pageIndex} setPageCount={setPageCount} setPageIndex={setPageIndex} />
+                  <Form
+                    setSearching={setSearching}
+                    pageIndex={pageIndex}
+                    setPageCount={setPageCount}
+                    setPageIndex={setPageIndex}
+                  />
                   <SearchList
                     searching={searching}
                     hideResults={hideResults}

--- a/lib/components/popups/course-search/cart/CartCourseList.tsx
+++ b/lib/components/popups/course-search/cart/CartCourseList.tsx
@@ -35,7 +35,6 @@ const CartCourseList: FC<{
   const courses = useSelector(selectRetrievedCourses);
   const placeholder = useSelector(selectPlaceholder);
   const dispatch = useDispatch();
-
   const coursesPerPage = 10;
 
   // Updates pagination every time the searched courses change.

--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -25,12 +25,12 @@ import { selectPlan } from '../../../../slices/currentPlanSlice';
  *
  * @prop setSearching - sets searching state
  */
-const Form: FC<{ 
-  setSearching: (searching: boolean) => void; 
-  pageIndex: number; 
-  setPageCount: Function; 
-  setPageIndex: Function; 
-}> = ({setSearching, pageIndex, setPageCount, setPageIndex}) => {
+const Form: FC<{
+  setSearching: (searching: boolean) => void;
+  pageIndex: number;
+  setPageCount: Function;
+  setPageIndex: Function;
+}> = ({ setSearching, pageIndex, setPageCount, setPageIndex }) => {
   // Set up redux dispatch and variables.
   const dispatch = useDispatch();
   const searchTerm = useSelector(selectSearchterm);
@@ -100,7 +100,7 @@ const Form: FC<{
   useEffect(() => {
     setPageIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, searchFilters])
+  }, [searchTerm, searchFilters]);
 
   // Search with debouncing of 4/8s of a second.
   useEffect(() => {
@@ -140,10 +140,7 @@ const Form: FC<{
 
     if (searchTerm.length > 0) {
       // Search with half second debounce.
-      const search = setTimeout(
-        performSmartSearch(extras),
-        500,
-      );
+      const search = setTimeout(performSmartSearch(extras), 500);
       return () => clearTimeout(search);
     } else {
       setSearching(false);
@@ -159,17 +156,16 @@ const Form: FC<{
    * @returns reference to a function that conducts smart search
    */
   const performSmartSearch =
-    (
-      extras: SearchExtras,
-    ): (() => void) =>
+    (extras: SearchExtras): (() => void) =>
     (): void => {
       axios
         .get(getAPI(window) + '/search', {
           params: getParams(extras),
         })
         .then((retrieved) => {
-          let retrievedCourses: SISRetrievedCourse[] = retrieved.data.data.courses;
-          const pageCount = retrieved.data.data.pagination.last; 
+          let retrievedCourses: SISRetrievedCourse[] =
+            retrieved.data.data.courses;
+          const pageCount = retrieved.data.data.pagination.last;
           setPageCount(pageCount);
           dispatch(updateRetrievedCourses(retrievedCourses));
           setSearching(false);

--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -15,21 +15,9 @@ import {
 } from '../../../../resources/commonTypes';
 import 'react-toastify/dist/ReactToastify.css';
 import Filters from './Filters';
-import {
-  selectCourseCache,
-  selectRetrievedAll,
-  updateCourseCache,
-} from '../../../../slices/userSlice';
 import axios from 'axios';
-import { getAPI } from '../../../../resources/assets';
-import { filterCourses } from './formUtils';
+import { getAPI, getParams } from '../../../../resources/assets';
 import { selectPlan } from '../../../../slices/currentPlanSlice';
-
-type SearchMapEl = {
-  course: SISRetrievedCourse;
-  version: number;
-  priority: number;
-};
 
 /**
  * Search form, including the search query input and filters.
@@ -37,46 +25,22 @@ type SearchMapEl = {
  *
  * @prop setSearching - sets searching state
  */
-const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
+const Form: FC<{ 
+  setSearching: (searching: boolean) => void; 
+  pageIndex: number; 
+  setPageCount: Function; 
+  setPageIndex: Function; 
+}> = ({setSearching, pageIndex, setPageCount, setPageIndex}) => {
   // Set up redux dispatch and variables.
   const dispatch = useDispatch();
   const searchTerm = useSelector(selectSearchterm);
   const searchFilters = useSelector(selectSearchFilters);
   const semester = useSelector(selectSemester);
-  const courseCache = useSelector(selectCourseCache);
-  const retrievedAll = useSelector(selectRetrievedAll);
   const currentPlan = useSelector(selectPlan);
   const searchYear = useSelector(selectYear);
 
   // Component state setup
   const [showCriteria, setShowCriteria] = useState(false);
-  const [searchedCourses] = useState<Map<string, SearchMapEl>>(
-    new Map<string, SearchMapEl>(),
-  );
-  const [searchedCoursesFrequency] = useState<Map<string, number>>(
-    new Map<string, number>(),
-  );
-  const [initialQueryLength, setInitialQueryLength] = useState<number>(0);
-  const [searchedQuery, setSearchedQuery] = useState<any | null>(null);
-
-  // In order to make sure our search results correctly match our search term due to the asynchronous nature of finds.
-  // We use this hook to make sure that the search results are updated when the search term matches the term used for the search result.
-  useEffect(() => {
-    if (searchedQuery !== null) {
-      if (
-        searchedQuery.total === searchedQuery.cum &&
-        searchedQuery.originalQuery === searchTerm
-      ) {
-        handleFinishFinding(
-          searchedQuery.courses,
-          searchedQuery.versions,
-          searchedQuery.queryLength,
-          searchedQuery.extras,
-        );
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchedQuery]);
 
   const getYearVal = (): number => {
     let year: number = new Date().getFullYear();
@@ -133,11 +97,13 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
       );
   };
 
-  // Search with debouncing of 2/4s of a second.
-  const minLength = 4;
   useEffect(() => {
-    searchedCourses.clear();
-    setInitialQueryLength(searchTerm.length);
+    setPageIndex(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchTerm, searchFilters])
+
+  // Search with debouncing of 4/8s of a second.
+  useEffect(() => {
     // Skip searching if no filters or queries are specified
     if (
       searchTerm.length === 0 &&
@@ -149,11 +115,12 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
       searchFilters.levels === null
     ) {
       dispatch(updateRetrievedCourses([]));
-      props.setSearching(false);
+      setSearching(false);
       return;
     }
     // Search params.
     const extras: SearchExtras = {
+      page: pageIndex,
       query: searchTerm,
       credits: searchFilters.credits,
       areas: searchFilters.distribution,
@@ -168,179 +135,21 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
       levels: searchFilters.levels,
     };
 
-    props.setSearching(true);
+    setSearching(true);
+    dispatch(updateRetrievedCourses([]));
 
     if (searchTerm.length > 0) {
       // Search with half second debounce.
       const search = setTimeout(
-        performSmartSearch(searchTerm, extras, searchTerm.length),
+        performSmartSearch(extras),
         500,
       );
       return () => clearTimeout(search);
     } else {
-      find(extras).then((found) => dispatch(updateRetrievedCourses(found[0])));
+      setSearching(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, searchFilters]);
-
-  /**
-   * Finds course based on the search conditions given in extras.
-   * Finds all relevant courses by starting with all courses and filtering them out.
-   * @param extras - search params
-   * @returns a promise that resolves when searching is concluded
-   */
-  const find = (
-    extras: SearchExtras,
-  ): Promise<[SISRetrievedCourse[], number[]]> => {
-    return new Promise(async (resolve) => {
-      let courses: SISRetrievedCourse[] = [...courseCache];
-      if (!retrievedAll) {
-        const retrieved: any = await axios
-          .get(getAPI(window) + '/search', {
-            params: getParams(extras),
-          })
-          .catch(() => {
-            return [[], []];
-          });
-        let SISRetrieved: SISRetrievedCourse[] = processedRetrievedData(
-          retrieved.data.data,
-          extras,
-        );
-        return resolve([SISRetrieved, []]);
-      } else {
-        const filterProcessing = filterCourses(extras, courses);
-        if (filterProcessing) return filterProcessing;
-        return resolve([courses, []]);
-      }
-    });
-  };
-
-  /**
-   * Processes retrieved data after searching
-   * @param data - retrieved data
-   * @param extras - search params
-   * @returns SISRetrieved - processed data
-   */
-  const processedRetrievedData = (
-    data: SISRetrievedCourse[],
-    extras: SearchExtras,
-  ): SISRetrievedCourse[] => {
-    let SISRetrieved: SISRetrievedCourse[] = data;
-    // This filtering needs to be done because backend returns courses with incorrect term and year matching. This needs to be fixed.
-    SISRetrieved = SISRetrieved.filter((course) => {
-      for (let version of course.versions) {
-        if (
-          version.term === extras.term + ' ' + extras.year ||
-          extras.term === 'All' ||
-          extras.year === 'All'
-        )
-          return true;
-      }
-      return false;
-    });
-    if (
-      extras.query.length <= minLength ||
-      searchTerm.length - extras.query.length >= 2
-    ) {
-      props.setSearching(false);
-    }
-    return SISRetrieved;
-  };
-
-  /**
-   * Searches for all subquery combinations for the specific substring length, queryLength.
-
-   * @param extras - search params
-   * @param queryLength - length of search query
-   * @param querySubstrs - an array of different substring combinations of search query
-   */
-  const substringSearch = async (
-    originalQuery: string,
-    extras: SearchExtras,
-    queryLength: number,
-    querySubstrs: string[],
-  ): Promise<void> => {
-    let courses: SISRetrievedCourse[] = [];
-    let versions: number[] = [];
-    let total = 0;
-    let cum = 0;
-    querySubstrs.forEach(async (subQuery) => {
-      total++;
-      const courseVersions = await find({
-        ...extras,
-        query: subQuery,
-      });
-      cum++;
-      courses.push(...courseVersions[0]);
-      versions.push(...courseVersions[1]);
-      setSearchedQuery({
-        total,
-        cum,
-        originalQuery,
-        courses,
-        versions,
-        queryLength,
-        extras,
-      });
-    });
-  };
-
-  // Handles the finishing of finding courses.
-  // tracks the number of times a course appears in the searchedCourses after a search
-  // and presumably uses it to sort the list by relevancy (the map thingy)
-  // also recursively calls the smartSearch
-  const handleFinishFinding = (
-    courses: SISRetrievedCourse[],
-    versions: number[],
-    queryLength: number,
-    extras: SearchExtras,
-  ) => {
-    courses.forEach((course: SISRetrievedCourse, index: number) => {
-      if (!searchedCourses.has(course.number + '0')) {
-        searchedCourses.set(course.number + '0', {
-          course: course,
-          version: versions[index],
-          priority: queryLength,
-        });
-        searchedCoursesFrequency.set(course.number, 1);
-      } else {
-        handleFrequency(course, versions, queryLength, index);
-      }
-    });
-    const newSearchList: SISRetrievedCourse[] = getNewSearchList();
-    dispatch(updateRetrievedCourses(newSearchList));
-    if (queryLength > minLength && initialQueryLength - queryLength < 9) {
-      performSmartSearch(extras.query, extras, queryLength - 1)();
-    }
-  };
-
-  // Handles the frequency of a course.
-  const handleFrequency = (
-    course: SISRetrievedCourse,
-    versions,
-    queryLength: number,
-    index: number,
-  ) => {
-    let frequency = searchedCoursesFrequency.get(course.number);
-    let flag = false;
-    if (frequency !== undefined) {
-      for (let i = 0; i < frequency; i++) {
-        if (
-          searchedCourses.get(course.number + i)?.course.title === course.title
-        ) {
-          flag = true;
-        }
-      }
-      if (!flag) {
-        searchedCourses.set(course.number + frequency, {
-          course: course,
-          version: versions[index],
-          priority: queryLength,
-        });
-        searchedCoursesFrequency.set(course.number, frequency + 1);
-      }
-    }
-  };
+  }, [searchTerm, searchFilters, pageIndex]);
 
   /**
    * Performs search call with filters to backend and updates redux with retrieved courses.
@@ -351,73 +160,29 @@ const Form: FC<{ setSearching: (searching: boolean) => void }> = (props) => {
    */
   const performSmartSearch =
     (
-      originalQuery: string,
       extras: SearchExtras,
-      queryLength: number,
     ): (() => void) =>
     (): void => {
-      const querySubstrs: string[] = [];
-      if (queryLength >= minLength) {
-        // Finds all substring combinations and searches.
-        for (let i = 0; i < searchTerm.length - queryLength + 1; i++) {
-          querySubstrs.push(searchTerm.substring(i, i + queryLength));
-        }
-        substringSearch(originalQuery, extras, queryLength, querySubstrs);
-      } else if (queryLength > 0 && queryLength < minLength) {
-        // Perform normal search if query length is between 1 and minLength
-        axios
-          .get(getAPI(window) + '/search', {
-            params: getParams(extras),
-          })
-          .then((retrieved) => {
-            let retrievedCourses: SISRetrievedCourse[] = retrieved.data.data;
-            dispatch(updateCourseCache(retrievedCourses));
-            dispatch(updateRetrievedCourses(retrievedCourses));
-            props.setSearching(false);
-          })
-          .catch(() => {
-            props.setSearching(false);
-          });
-      } else {
-        props.setSearching(false);
-      }
+      axios
+        .get(getAPI(window) + '/search', {
+          params: getParams(extras),
+        })
+        .then((retrieved) => {
+          let retrievedCourses: SISRetrievedCourse[] = retrieved.data.data.courses;
+          const pageCount = retrieved.data.data.pagination.last; 
+          setPageCount(pageCount);
+          dispatch(updateRetrievedCourses(retrievedCourses));
+          setSearching(false);
+        })
+        .catch(() => {
+          setSearching(false);
+        });
     };
-
-  /**
-   * Gets new list of searched courses.
-   * @returns an array of retrieved courses
-   */
-  const getNewSearchList = (): SISRetrievedCourse[] => {
-    let searchList: SISRetrievedCourse[] = [];
-    // sorts searchedCourses map by priority.
-    searchedCourses[Symbol.iterator] = function* () {
-      yield* [...this.entries()]
-        .sort((a, b) => a[1].course.title.length - b[1].course.title.length)
-        .sort((a, b) => b[1].priority - a[1].priority);
-    };
-    for (let [, value] of searchedCourses) {
-      searchList.push(value.course);
-    }
-    return searchList;
-  };
 
   // Update search term
   const handleSearchTerm = (event: any): void => {
     dispatch(updateSearchTerm(event.target.value));
   };
-
-  // Returns search fetch params
-  const getParams = (extras: SearchExtras) => ({
-    query: extras.query,
-    department: extras.department,
-    term: extras.term,
-    areas: extras.areas,
-    credits: extras.credits,
-    wi: extras.wi,
-    tags: extras.tags,
-    level: extras.levels,
-    year: extras.year,
-  });
 
   return (
     <div className="w-full h-auto px-5 pt-3 border-b border-gray-400 select-none text-coursecard">

--- a/lib/components/popups/course-search/query-components/SearchList.tsx
+++ b/lib/components/popups/course-search/query-components/SearchList.tsx
@@ -25,7 +25,7 @@ const SearchList: FC<{
   searching: boolean;
   hideResults: boolean;
   setHideResults: Function;
-  setPageIndex: Function; 
+  setPageIndex: Function;
 }> = ({ searching, hideResults, setHideResults, setPageIndex }) => {
   // Component state setup.
   const [filteredCourses, setFilteredCourses] = useState<SISRetrievedCourse[]>(
@@ -59,10 +59,10 @@ const SearchList: FC<{
       for (let j = 0; j < inspecting.versions.length; j++) {
         const v = inspecting.versions[j];
         if (
-          (v.term === searchFilters.term + ' ' + searchFilters.year ||
-            (searchFilters.term === 'All' &&
-              (searchFilters.year === currentPlan.years[0].year ||
-                searchFilters.year.toString() === v.term.split(' ')[1])))
+          v.term === searchFilters.term + ' ' + searchFilters.year ||
+          (searchFilters.term === 'All' &&
+            (searchFilters.year === currentPlan.years[0].year ||
+              searchFilters.year.toString() === v.term.split(' ')[1]))
         ) {
           toDisplay.push(
             <div
@@ -124,7 +124,11 @@ const SearchList: FC<{
   const getPaginationUI = () =>
     pageCount > 1 && (
       <div className="flex flex-row justify-center w-full h-auto">
-        <Pagination pageCount={pageCount} pageIndex={pageIndex} handlePageClick={handlePageClick} />
+        <Pagination
+          pageCount={pageCount}
+          pageIndex={pageIndex}
+          handlePageClick={handlePageClick}
+        />
       </div>
     );
 
@@ -203,7 +207,7 @@ type PaginationProps = {
 
 const Pagination: React.FC<PaginationProps> = ({
   pageCount,
-  pageIndex, 
+  pageIndex,
   handlePageClick,
 }) => {
   /* A Pagination component we'll use! Prop list and docs here: https://github.com/AdeleD/react-paginate. '

--- a/lib/components/popups/course-search/query-components/SearchList.tsx
+++ b/lib/components/popups/course-search/query-components/SearchList.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, FC } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
+  selectPageCount,
+  selectPageIndex,
   selectPlaceholder,
   selectRetrievedCourses,
   selectSearchFilters,
   updateInspectedVersion,
+  updatePageIndex,
   updatePlaceholder,
 } from '../../../../slices/searchSlice';
 import CourseCard from './CourseCard';
@@ -22,10 +25,9 @@ const SearchList: FC<{
   searching: boolean;
   hideResults: boolean;
   setHideResults: Function;
-}> = ({ searching, hideResults, setHideResults }) => {
+  setPageIndex: Function; 
+}> = ({ searching, hideResults, setHideResults, setPageIndex }) => {
   // Component state setup.
-  const [pageNum, setPageNum] = useState<number>(0);
-  const [pageCount, setPageCount] = useState<number>(0);
   const [filteredCourses, setFilteredCourses] = useState<SISRetrievedCourse[]>(
     [],
   );
@@ -35,20 +37,13 @@ const SearchList: FC<{
   const placeholder = useSelector(selectPlaceholder);
   const searchFilters = useSelector(selectSearchFilters);
   const currentPlan = useSelector(selectPlan);
+  const pageIndex = useSelector(selectPageIndex);
+  const pageCount = useSelector(selectPageCount);
   const dispatch = useDispatch();
-
-  let coursesPerPage = 10;
 
   // Updates pagination every time the searched courses change.
   useEffect(() => {
     const SISFilteredCourses: SISRetrievedCourse[] = courses;
-    // If coursesPerPage doesn't divide perfectly into total courses, we need one more page.
-    const division = Math.floor(SISFilteredCourses.length / coursesPerPage);
-    const pages =
-      SISFilteredCourses.length % coursesPerPage === 0
-        ? division
-        : division + 1;
-    setPageCount(pages);
     setFilteredCourses(SISFilteredCourses);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courses, searchFilters]);
@@ -59,42 +54,29 @@ const SearchList: FC<{
    */
   const courseList = () => {
     let toDisplay: any = [];
-    let startingIndex = pageNum * coursesPerPage;
-    let endingIndex =
-      startingIndex + coursesPerPage > filteredCourses.length
-        ? filteredCourses.length - 1
-        : startingIndex + coursesPerPage - 1;
-    for (let i = startingIndex; i <= endingIndex; i++) {
-      let inserted: string[] = [];
+    for (let i = 0; i < filteredCourses.length; i++) {
       const inspecting = { ...filteredCourses[i] };
-      inspecting.versions.forEach((v: any, versionNum: number) => {
-        let alreadyInserted = false;
-        inserted.forEach((term: string) => {
-          if (term.includes(v.term)) {
-            alreadyInserted = true;
-          }
-        });
+      for (let j = 0; j < inspecting.versions.length; j++) {
+        const v = inspecting.versions[j];
         if (
-          !alreadyInserted &&
           (v.term === searchFilters.term + ' ' + searchFilters.year ||
             (searchFilters.term === 'All' &&
               (searchFilters.year === currentPlan.years[0].year ||
                 searchFilters.year.toString() === v.term.split(' ')[1])))
         ) {
-          inserted.push(v.term);
           toDisplay.push(
             <div
-              key={inspecting.number + v.term + versionNum}
+              key={inspecting._id}
               className="transition duration-200 ease-in transform hover:scale-105"
               onClick={() =>
                 window.innerWidth < 1200 ? setHideResults(true) : null
               }
             >
-              <CourseCard course={inspecting} version={versionNum} />
+              <CourseCard course={inspecting} version={j} />
             </div>,
           );
         }
-      });
+      }
     }
     return toDisplay;
   };
@@ -104,7 +86,7 @@ const SearchList: FC<{
    * @param event event raised on changing search result page
    */
   const handlePageClick = (event: any) => {
-    setPageNum(event.selected);
+    dispatch(updatePageIndex(event.selected));
   };
 
   /**
@@ -142,7 +124,7 @@ const SearchList: FC<{
   const getPaginationUI = () =>
     pageCount > 1 && (
       <div className="flex flex-row justify-center w-full h-auto">
-        <Pagination pageCount={pageCount} handlePageClick={handlePageClick} />
+        <Pagination pageCount={pageCount} pageIndex={pageIndex} handlePageClick={handlePageClick} />
       </div>
     );
 
@@ -215,11 +197,13 @@ const SearchList: FC<{
 // Below is the pagination component.
 type PaginationProps = {
   pageCount: number;
+  pageIndex: number;
   handlePageClick: any;
 };
 
 const Pagination: React.FC<PaginationProps> = ({
   pageCount,
+  pageIndex, 
   handlePageClick,
 }) => {
   /* A Pagination component we'll use! Prop list and docs here: https://github.com/AdeleD/react-paginate. '
@@ -233,6 +217,7 @@ const Pagination: React.FC<PaginationProps> = ({
       breakLabel={'...'}
       breakClassName={'justify-items-end h-6 mt-1'}
       pageCount={pageCount}
+      forcePage={pageIndex}
       marginPagesDisplayed={2}
       pageRangeDisplayed={3}
       onPageChange={handlePageClick}

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -8,6 +8,7 @@ import {
   UserCourse,
   SISRetrievedCourse,
   Year,
+  SearchExtras,
 } from './commonTypes';
 import { allMajors } from './majors';
 import { store } from '../appStore/store';
@@ -52,6 +53,19 @@ export const getColors = function (
     return '#83B9FF';
   }
 };
+
+export const getParams = (extras: SearchExtras) => ({
+  page: extras.page,
+  query: extras.query,
+  department: extras.department,
+  term: extras.term === 'All' ? '' : extras.term,
+  year: extras.year === 'All' ? '' : extras.year,
+  areas: extras.areas,
+  credits: extras.credits,
+  wi: extras.wi,
+  tags: extras.tags,
+  level: extras.levels,
+});
 
 // On SIS, scrape the majors using the console, check Notion for more info
 export const AS_deps = [
@@ -495,6 +509,7 @@ export const getCourse = async (
         return resolve({ index: indexNum, resp: out });
       }
     }
+    console.log(courseNumber); 
 
     if (out === null) {
       if (store.getState().user.unfoundNumbers.includes(courseNumber)) {
@@ -517,7 +532,7 @@ const backendSearch = async (
       })
       .catch((err) => console.log(err));
     if (courses === undefined) return Promise.reject();
-    let retrieved: SISRetrievedCourse = courses.data.data[0];
+    let retrieved: SISRetrievedCourse = courses.data.data.courses[0];
     if (retrieved === undefined) {
       store.dispatch(updateUnfoundNumbers(courseNumber));
       return resolve({ index: indexNum, resp: null });
@@ -529,7 +544,9 @@ const backendSearch = async (
         versionIndex = index;
       }
     });
-    store.dispatch(updateCourseCache(courses.data.data));
+    const cache: SISRetrievedCourse[] = []; 
+    cache.push(retrieved);
+    store.dispatch(updateCourseCache(cache));
     resolve({
       index: indexNum,
       resp: {

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -509,7 +509,7 @@ export const getCourse = async (
         return resolve({ index: indexNum, resp: out });
       }
     }
-    console.log(courseNumber); 
+    console.log(courseNumber);
 
     if (out === null) {
       if (store.getState().user.unfoundNumbers.includes(courseNumber)) {
@@ -544,7 +544,7 @@ const backendSearch = async (
         versionIndex = index;
       }
     });
-    const cache: SISRetrievedCourse[] = []; 
+    const cache: SISRetrievedCourse[] = [];
     cache.push(retrieved);
     store.dispatch(updateCourseCache(cache));
     resolve({

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -509,7 +509,6 @@ export const getCourse = async (
         return resolve({ index: indexNum, resp: out });
       }
     }
-    console.log(courseNumber);
 
     if (out === null) {
       if (store.getState().user.unfoundNumbers.includes(courseNumber)) {

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -44,6 +44,7 @@ export type Version = {
 };
 
 export type SISRetrievedCourse = {
+  _id: string; 
   title: string;
   number: string;
   terms: string[];
@@ -139,6 +140,7 @@ export type Filter = {
 };
 
 export type SearchExtras = {
+  page: number | null; 
   query: string;
   credits: string | null;
   areas: string | null;

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -44,7 +44,7 @@ export type Version = {
 };
 
 export type SISRetrievedCourse = {
-  _id: string; 
+  _id: string;
   title: string;
   number: string;
   terms: string[];
@@ -140,7 +140,7 @@ export type Filter = {
 };
 
 export type SearchExtras = {
-  page: number | null; 
+  page: number | null;
   query: string;
   credits: string | null;
   areas: string | null;

--- a/lib/slices/searchSlice.ts
+++ b/lib/slices/searchSlice.ts
@@ -43,6 +43,8 @@ type searchStates = {
   placeholder: boolean;
   searchStack: { sis: SISRetrievedCourse; ver: Course }[];
   cartAdd: boolean;
+  pageIndex: number; 
+  pageCount: number; 
 };
 
 type searchStackUpdate = {
@@ -75,6 +77,8 @@ const initialState: searchStates = {
   placeholder: false,
   searchStack: [],
   cartAdd: false,
+  pageIndex: 0,
+  pageCount: 1,
 };
 
 export const searchSlice = createSlice({
@@ -179,6 +183,12 @@ export const searchSlice = createSlice({
     updateCartAdd: (state: any, action: PayloadAction<boolean>) => {
       state.cartAdd = action.payload;
     },
+    updatePageIndex: (state: any, action: PayloadAction<number>) => {
+      state.pageIndex = action.payload;
+    },
+    updatePageCount: (state: any, action: PayloadAction<number>) => {
+      state.pageCount = action.payload;
+    },
   },
 });
 
@@ -195,6 +205,8 @@ export const {
   clearSearch,
   popSearchStack,
   updateCartAdd,
+  updatePageIndex, 
+  updatePageCount
 } = searchSlice.actions;
 
 // The function below is called a selector and allows us to select a value from
@@ -215,5 +227,7 @@ export const selectSearchStack = (state: RootState) => state.search.searchStack;
 export const selectVersion = (state: RootState) =>
   state.search.inspectedVersion;
 export const selectCartAdd = (state: RootState) => state.search.cartAdd;
+export const selectPageIndex = (state: RootState) => state.search.pageIndex;
+export const selectPageCount = (state: RootState) => state.search.pageCount;
 
 export default searchSlice.reducer;

--- a/lib/slices/searchSlice.ts
+++ b/lib/slices/searchSlice.ts
@@ -43,8 +43,8 @@ type searchStates = {
   placeholder: boolean;
   searchStack: { sis: SISRetrievedCourse; ver: Course }[];
   cartAdd: boolean;
-  pageIndex: number; 
-  pageCount: number; 
+  pageIndex: number;
+  pageCount: number;
 };
 
 type searchStackUpdate = {
@@ -205,8 +205,8 @@ export const {
   clearSearch,
   popSearchStack,
   updateCartAdd,
-  updatePageIndex, 
-  updatePageCount
+  updatePageIndex,
+  updatePageCount,
 } = searchSlice.actions;
 
 // The function below is called a selector and allows us to select a value from

--- a/lib/slices/userSlice.ts
+++ b/lib/slices/userSlice.ts
@@ -102,9 +102,6 @@ export const userSlice = createSlice({
         state.courseCache = [...action.payload];
       }
     },
-    updateRetrievedAll: (state: any, action: PayloadAction<Boolean>) => {
-      state.retrievedAll = action.payload;
-    },
     updateImportID: (state: any, action: PayloadAction<String>) => {
       state.importId = action.payload;
     },
@@ -145,7 +142,6 @@ export const {
   updateGuestPlanIds,
   updateCourseCache,
   updateAllCoursesCached,
-  updateRetrievedAll,
   updateUnfoundNumbers,
   updateImportID,
   updateReviewerPlanID,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,31 +1,15 @@
-import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 // import { toast } from 'react-toastify';
-import { getAPI } from '../lib/resources/assets';
 import {
-  selectCourseCache,
-  selectToken,
   selectUser,
-  // updateAllCoursesCached,
-  updateCourseCache,
-  // updateRetrievedAll,
 } from '../lib/slices/userSlice';
-import {
-  // SISRetrievedCourse,
-  UserCourse,
-  Year,
-} from '../lib/resources/commonTypes';
-import { selectPlan } from '../lib/slices/currentPlanSlice';
+
 import LandingPage from '../lib/components/landing-page';
 import Head from 'next/head';
 
 const Home: React.FC = () => {
-  const dispatch = useDispatch();
   const user = useSelector(selectUser);
-  const curPlan = useSelector(selectPlan);
-  const courseCache = useSelector(selectCourseCache);
-  const token = useSelector(selectToken);
 
   // Component state setup.
   const [welcomeScreen, setWelcomeScreen] = useState<boolean>(false);
@@ -63,50 +47,6 @@ const Home: React.FC = () => {
       setWelcomeScreen(true);
     }
   }, [user, needsToLoad, welcomeScreen]);
-
-  const courseCheck = (): boolean => {
-    let hasCourses: boolean = false;
-    curPlan.years.forEach((year: Year) => {
-      if (year.courses.length !== 0) {
-        hasCourses = true;
-      }
-    });
-    return hasCourses;
-  };
-
-  useEffect(() => {
-    const planHasCourses: boolean = courseCheck();
-    if (
-      courseCache.length === 0 &&
-      curPlan._id !== 'noPlan' &&
-      planHasCourses
-    ) {
-      setNeedsToLoad(true);
-      axios
-        .get(getAPI(window) + '/coursesByPlan/' + curPlan._id, {
-          headers: { Authorization: `Bearer ${token}` },
-        })
-        .then((response) => {
-          response.data.data.forEach((c: UserCourse) => {
-            axios
-              .get(getAPI(window) + '/search', {
-                params: { query: c.number },
-                // eslint-disable-next-line no-loop-func
-              })
-              .then((retrieved) => {
-                dispatch(updateCourseCache(retrieved.data.data));
-              })
-              .catch((err) => {
-                console.log(err);
-              });
-          });
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [curPlan._id]);
 
   return (
     <>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 // import { toast } from 'react-toastify';
-import {
-  selectUser,
-} from '../lib/slices/userSlice';
+import { selectUser } from '../lib/slices/userSlice';
 
 import LandingPage from '../lib/components/landing-page';
 import Head from 'next/head';


### PR DESCRIPTION
Backend PR : https://github.com/uCredit-Dev/uCredit-API/pull/69 

# Search result pagination 
- migrate `performSmartSearch` logic to backend
- integrate frontend with new /search route and pagination 
- remove unnecessary filtering of courses (backend does all filtering)
- cache courses once with `/api/coursesByPlan` route instead of multiple `/search` calls 
  - !! work in progress !!

note: course searches for prereq checking and fine requirements still uses same search logic now `/cartSearch`. Better done as part of the distributions migration project... 

# Implementations
See under files changed tab 

# Testing
Tested search locally by course title, number, with various applicable filters. Confirmed that prereq checking and fine requirements searching still works. 

todo: try importing plan / reviewing plan 