### PR TITLE
DIS-32 make total credits bar unclickable

### DIFF
--- a/lib/components/dashboard/degree-info/CourseBar.tsx
+++ b/lib/components/dashboard/degree-info/CourseBar.tsx
@@ -62,16 +62,12 @@ const CourseBar: FC<{
   const openCartPopup = async () => {
     dispatch(updateCartInvokedBySemester(false));
     // Filter for the correst distributions from redux store
-    let distr: UserDistribution = distribution;
-    // get fineReqs
-    if (distribution._id) {
-      distr = await getDistribution(distribution._id, token);
-    }
-    if (distr) {
+    let distrs = distributions.filter((req) => req[0] === distribution.name)[0];
+    if (distrs) {
       // if the distribution exists, then update the cart
       // at this point we have access to the current requirement
       // and all dsitibrutions. to pick out hte rest of the ascoatied fine distirbutions, use this filter.
-      dispatch(updateSelectedDistribution(distr));
+      dispatch(updateSelectedDistribution(distrs));
       dispatch(updateSelectedFineReq(null));
       dispatch(updateShowingCart(true));
       dispatch(updateInfoPopup(false));

--- a/lib/components/dashboard/degree-info/CourseBar.tsx
+++ b/lib/components/dashboard/degree-info/CourseBar.tsx
@@ -15,10 +15,7 @@ import {
   updateShowingCart,
 } from '../../../slices/popupSlice';
 import { clearSearch, updatePlaceholder } from '../../../slices/searchSlice';
-import {
-  selectToken,
-  updateCartInvokedBySemester,
-} from '../../../slices/userSlice';
+import { updateCartInvokedBySemester } from '../../../slices/userSlice';
 import Comments from '../Comments';
 import { ReviewMode, UserDistribution } from '../../../resources/commonTypes';
 

--- a/lib/components/dashboard/degree-info/CourseBar.tsx
+++ b/lib/components/dashboard/degree-info/CourseBar.tsx
@@ -21,7 +21,6 @@ import {
 } from '../../../slices/userSlice';
 import Comments from '../Comments';
 import { ReviewMode, UserDistribution } from '../../../resources/commonTypes';
-import { getDistribution } from '../../../resources/assets';
 
 /**
  * A distribution bar.
@@ -40,7 +39,6 @@ const CourseBar: FC<{
   const [plannedCredits, setPlannedCredits] = useState(distribution.planned);
   const [hovered, setHovered] = useState(false);
 
-  const token = useSelector(selectToken);
   const currPlanCourses = useSelector(selectCurrentPlanCourses);
   const maxCredits = distribution.required_credits;
   const section = distribution.name;

--- a/lib/components/dashboard/degree-info/InfoMenu.tsx
+++ b/lib/components/dashboard/degree-info/InfoMenu.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect } from 'react';
 import Distributions from './Distributions';
 import { useSelector } from 'react-redux';
 import {
-  selectCurrentPlanCourses,
   selectPlan,
   selectSelectedMajor,
   updateSelectedMajor,

--- a/lib/components/dashboard/degree-info/InfoMenu.tsx
+++ b/lib/components/dashboard/degree-info/InfoMenu.tsx
@@ -20,7 +20,6 @@ interface Props {
  */
 const InfoMenu: FC<Props> = () => {
   const currentPlan: Plan = useSelector(selectPlan);
-  const currPlanCourses = useSelector(selectCurrentPlanCourses);
   const major_id = useSelector(selectSelectedMajor);
   const dispatch = useDispatch();
 

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -168,46 +168,48 @@ const CourseDisplayPopup: FC = () => {
   };
 
   // Handles post add course post response
-  const handlePostAddCourse = (plan: Plan) => (data): void => {
-    let newUserCourse: UserCourse;
-    if (data.errors === undefined && courseToShow !== null) {
-      newUserCourse = { ...data.data };
-      dispatch(updateCurrentPlanCourses([...currentCourses, newUserCourse]));
-      const allYears: Year[] = [...plan.years];
-      const newYears: Year[] = [];
-      allYears.forEach(updateYears(newYears, newUserCourse));
-      const newPlan: Plan = { ...plan, years: newYears };
-      dispatch(updateSelectedPlan(newPlan));
-      const newPlanList = [...planList];
-      for (let i = 0; i < planList.length; i++) {
-        if (planList[i]._id === newPlan._id) {
-          newPlanList[i] = newPlan;
+  const handlePostAddCourse =
+    (plan: Plan) =>
+    (data): void => {
+      let newUserCourse: UserCourse;
+      if (data.errors === undefined && courseToShow !== null) {
+        newUserCourse = { ...data.data };
+        dispatch(updateCurrentPlanCourses([...currentCourses, newUserCourse]));
+        const allYears: Year[] = [...plan.years];
+        const newYears: Year[] = [];
+        allYears.forEach(updateYears(newYears, newUserCourse));
+        const newPlan: Plan = { ...plan, years: newYears };
+        dispatch(updateSelectedPlan(newPlan));
+        const newPlanList = [...planList];
+        for (let i = 0; i < planList.length; i++) {
+          if (planList[i]._id === newPlan._id) {
+            newPlanList[i] = newPlan;
+          }
         }
+        dispatch(updatePlanList(newPlanList));
+        dispatch(updateCourseToShow(null));
+        dispatch(updateShowCourseInfo(false));
+        dispatch(clearSearch());
+        dispatch(updatePlaceholder(false));
+        toast.success('Course updated!', {
+          toastId: 'course updated',
+        });
+      } else {
+        console.log('Failed to add', data.errors);
       }
-      dispatch(updatePlanList(newPlanList));
-      dispatch(updateCourseToShow(null));
-      dispatch(updateShowCourseInfo(false));
-      dispatch(clearSearch());
-      dispatch(updatePlaceholder(false));
-      toast.success('Course updated!', {
-        toastId: 'course updated',
-      });
-    } else {
-      console.log('Failed to add', data.errors);
-    }
-  };
+    };
 
   // Helper method that updates the years array in the plan after adding course.
-  const updateYears = (newYears: Year[], newUserCourse: UserCourse) => (
-    year: Year,
-  ): void => {
-    if (courseToShow !== null && year._id === courseToShow.year_id) {
-      const yCourses = [...year.courses, newUserCourse];
-      newYears.push({ ...year, courses: yCourses });
-    } else {
-      newYears.push(year);
-    }
-  };
+  const updateYears =
+    (newYears: Year[], newUserCourse: UserCourse) =>
+    (year: Year): void => {
+      if (courseToShow !== null && year._id === courseToShow.year_id) {
+        const yCourses = [...year.courses, newUserCourse];
+        newYears.push({ ...year, courses: yCourses });
+      } else {
+        newYears.push(year);
+      }
+    };
 
   return (
     <div className="absolute top-0">

--- a/lib/components/popups/course-search/search-results/Placeholder.tsx
+++ b/lib/components/popups/course-search/search-results/Placeholder.tsx
@@ -55,15 +55,13 @@ const Placeholder: FC<{ addCourse: (plan?: Plan) => void }> = ({
   const dispatch = useDispatch();
 
   // Component state setup.
-  const [placeholderTitle, setPlaceholderTitle] = useState<string>(
-    'placeholder',
-  );
+  const [placeholderTitle, setPlaceholderTitle] =
+    useState<string>('placeholder');
   const [placeholderArea, setPlaceholderArea] = useState<string>('none');
   const [placeholderCredits, setPlaceholderCredits] = useState<string>('0');
   const [placeholderNumber, setPlaceholderNumber] = useState<string>('');
-  const [placeholderDepartment, setPlaceholderDepartment] = useState<string>(
-    'none',
-  );
+  const [placeholderDepartment, setPlaceholderDepartment] =
+    useState<string>('none');
   const [placeholderTag, setPlaceholderTag] = useState<string>('none');
   const [placeholderWI, setPlaceholderWI] = useState<boolean>(false);
   const [placeholderLevel, setPlaceholderLevel] = useState<string>('none');

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -317,7 +317,8 @@ export const processPrereqs = async (
 ): Promise<PrereqCourses> => {
   // Regex used to get an array of course numbers.
   const regex: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}/g;
-  const forwardSlashRegex: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}\/[A-Z]{2}\.\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/EN.XXX.XXX
+  const forwardSlashRegex: RegExp =
+    /[A-Z]{2}\.\d{3}\.\d{3}\/[A-Z]{2}\.\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/EN.XXX.XXX
   const forwardSlashRegex2: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}\/\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/XXX.XXX
   const forwardSlashRegex3: RegExp = /[A-Z]{2}\.\d{3}\/\d{3}\.\d{3}/g; // e.g. EN.XXX/XXX.XXX
 

--- a/lib/slices/currentPlanSlice.ts
+++ b/lib/slices/currentPlanSlice.ts
@@ -7,7 +7,7 @@ import {
   ThreadType,
   UserCourse,
   UserDistribution,
-  UserFineReq
+  UserFineReq,
 } from './../resources/commonTypes';
 type CurrentPlanSlice = {
   plan: Plan;
@@ -49,7 +49,7 @@ const initialState: CurrentPlanSlice = {
   selectedThread: null,
   selectedMajor: null,
   selectedDistribution: null,
-  selectedFineReq: null
+  selectedFineReq: null,
 };
 
 export const currentPlanSlice = createSlice({
@@ -171,7 +171,7 @@ export const {
   updateSelectedThread,
   updateSelectedMajor,
   updateSelectedDistribution,
-  updateSelectedFineReq
+  updateSelectedFineReq,
 } = currentPlanSlice.actions;
 
 // The function below is called a selector and allows us to select a value from

--- a/lib/slices/popupSlice.ts
+++ b/lib/slices/popupSlice.ts
@@ -1,10 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../appStore/store';
-import {
-  Major,
-  UserCourse,
-  Year,
-} from '../components/../resources/commonTypes';
+import { UserCourse, Year } from '../components/../resources/commonTypes';
 
 type PopupSlice = {
   deletePlan: boolean;


### PR DESCRIPTION
**Description**
In the distributions branch on frontend, clicking on the total credits bar in the tracker caused the app to crash. So the solution is to make the total credits bar unclickable. 

**Implementation**
In the CourseBar.tsx, openCartPopup function is called when the CourseBar is clicked. I made the total credits bar unclickable by changing how the correct distribution was filtered from the distributions. 

**Testing**
Tested locally but only on a new plan with no courses added. I have two dev accounts, mkim224 and mkim25, but for some reason they don't have majors in the plans containing courses (and thus only the total credits bar showed up in the tracker). So I created a new plan which meant distribution bars were shown in the tracker, but I couldn't add new courses and check that course counting and distribution tracking are working after making the total credits bar unclickable. 

I would like to conduct more testing locally once I figure out the issues with my dev accounts. 
