### PR TITLE
DEV-125: display toast on error response for adding courses

### DIFF
--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -261,9 +261,11 @@ const Semester: FC<{
     } else {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        toast.error(error.detail);
+        if(error.status == 400) {
+          toast.error(error.detail);
+          dispatch(updateAddingPrereq(false));
+        }
       });
-      dispatch(updateAddingPrereq(false));
     }
   };
 

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -260,6 +260,10 @@ const Semester: FC<{
       });
     } else {
       console.log('Failed to add', data.errors);
+      data.errors.forEach((error) => {
+        toast.error(error.detail);
+      });
+      dispatch(updateAddingPrereq(false));
     }
   };
 

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -261,7 +261,7 @@ const Semester: FC<{
     } else {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        if(error.status == 400) {
+        if (error.status == 400) {
           toast.error(error.detail);
           dispatch(updateAddingPrereq(false));
         }

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -261,7 +261,7 @@ const Semester: FC<{
     } else {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        if (error.status == 400) {
+        if (error.status === 400) {
           toast.error(error.detail);
           dispatch(updateAddingPrereq(false));
         }

--- a/lib/components/dashboard/menus/PlanEditMenu.tsx
+++ b/lib/components/dashboard/menus/PlanEditMenu.tsx
@@ -126,7 +126,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
   /**
    * Limit the max width of multi-select labels
    */
-  const customStyles: StylesConfig<typeof majorOptions[number], true> = {
+  const customStyles: StylesConfig<(typeof majorOptions)[number], true> = {
     multiValue: (provided) => {
       const maxWidth = '17rem';
       return { ...provided, maxWidth };
@@ -168,7 +168,7 @@ const PlanEditMenu: FC<{ mode: ReviewMode }> = ({ mode }) => {
    * if user selected more than one major
    */
   const MultiValue = (
-    props: MultiValueProps<typeof majorOptions[number], true>,
+    props: MultiValueProps<(typeof majorOptions)[number], true>,
   ) => {
     const major = allMajors.find(
       (majorObj) => majorObj.degree_name === props.data.label,

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -199,6 +199,9 @@ const CourseDisplayPopup: FC = () => {
         });
       } else {
         console.log('Failed to add', data.errors);
+        data.errors.forEach((error) => {
+          toast.error(error.detail);
+        });
       }
     };
 

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -200,7 +200,9 @@ const CourseDisplayPopup: FC = () => {
       } else {
         console.log('Failed to add', data.errors);
         data.errors.forEach((error) => {
-          toast.error(error.detail);
+          if(error.status == 400) {
+            toast.error(error.detail);
+          }
         });
       }
     };

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -200,7 +200,7 @@ const CourseDisplayPopup: FC = () => {
       } else {
         console.log('Failed to add', data.errors);
         data.errors.forEach((error) => {
-          if (error.status == 400) {
+          if (error.status === 400) {
             toast.error(error.detail);
           }
         });

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -200,7 +200,7 @@ const CourseDisplayPopup: FC = () => {
       } else {
         console.log('Failed to add', data.errors);
         data.errors.forEach((error) => {
-          if(error.status == 400) {
+          if (error.status == 400) {
             toast.error(error.detail);
           }
         });

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -124,7 +124,9 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
     if (data.errors !== undefined) {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        toast.error(error.detail);
+        if(error.status == 400) {
+          toast.error(error.detail);
+        }
       });
       return;
     }

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -123,6 +123,9 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
 
     if (data.errors !== undefined) {
       console.log('Failed to add', data.errors);
+      data.errors.forEach((error) => {
+        toast.error(error.detail);
+      });
       return;
     }
 

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -124,7 +124,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
     if (data.errors !== undefined) {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        if(error.status == 400) {
+        if (error.status == 400) {
           toast.error(error.detail);
         }
       });

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -124,7 +124,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
     if (data.errors !== undefined) {
       console.log('Failed to add', data.errors);
       data.errors.forEach((error) => {
-        if (error.status == 400) {
+        if (error.status === 400) {
           toast.error(error.detail);
         }
       });

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -317,7 +317,8 @@ export const processPrereqs = async (
 ): Promise<PrereqCourses> => {
   // Regex used to get an array of course numbers.
   const regex: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}/g;
-  const forwardSlashRegex: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}\/[A-Z]{2}\.\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/EN.XXX.XXX
+  const forwardSlashRegex: RegExp =
+    /[A-Z]{2}\.\d{3}\.\d{3}\/[A-Z]{2}\.\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/EN.XXX.XXX
   const forwardSlashRegex2: RegExp = /[A-Z]{2}\.\d{3}\.\d{3}\/\d{3}\.\d{3}/g; // e.g. EN.XXX.XXX/XXX.XXX
   const forwardSlashRegex3: RegExp = /[A-Z]{2}\.\d{3}\/\d{3}\.\d{3}/g; // e.g. EN.XXX/XXX.XXX
 

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -177,8 +177,8 @@ export type SemesterType =
   | 'All';
 
 // https://stackoverflow.com/questions/52085454/typescript-define-a-union-type-from-an-array-of-strings
-export type DepartmentType = typeof all_deps[number];
-export type TagType = typeof course_tags[number];
+export type DepartmentType = (typeof all_deps)[number];
+export type TagType = (typeof course_tags)[number];
 
 export type FilterType =
   | 'credits'


### PR DESCRIPTION
#### Description
If a user tries to add a duplicate course in the same semester, a toast error will be displayed and the course is not added.

#### Implementation
Works with DEV-125 branch on backend repo. 
Each time the add course route is called on front end, toast is displayed if error is returned and prints error message.
Also, when adding prereqs, the error causes adding prereq mode to close.

#### Testing
Local testing done

attempted to add the same course (i.e. adding Gateway Python twice) which triggers toast
![image](https://user-images.githubusercontent.com/89751747/222992496-884a080a-a2ae-4909-b77a-1f06ad5ba973.png)

attempted to add courses with same number but different names (i.e. two different ProfComm classes) which is allowed
![image](https://user-images.githubusercontent.com/89751747/222992862-7a0fcb9f-f9f2-45ee-bfcf-11ed74734971.png)