### PR TITLE
Dev 105: Comment Icon opens properly on click

### DIFF
--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -81,7 +81,8 @@ const Comments: FC<{
         setExpanded(false);
     };
     document.addEventListener('click', handleClickOutside, true);
-    return () => document.removeEventListener('click', handleClickOutside, true);
+    return () =>
+      document.removeEventListener('click', handleClickOutside, true);
   }, [wrapperRef, expanded]);
 
   const submitReply = async (e) => {

--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -80,8 +80,8 @@ const Comments: FC<{
       if (currentWrapperRef && !currentWrapperRef.contains(e.target))
         setExpanded(false);
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('click', handleClickOutside, true);
+    return () => document.removeEventListener('click', handleClickOutside, true);
   }, [wrapperRef, expanded]);
 
   const submitReply = async (e) => {


### PR DESCRIPTION
**Description:**
If a user opens the menu or the reviewer icon(the "person" icon in the action bar), a click on the comment icon no longer opens the comment view.

**Implementation:**
The issue is that, if the comment view is open, clicking outside the comment view will close it.  However, the click used to open the comment view triggers the corresponding event listener after the comment view is already openned, and the event listener then closes the comment view.  (In turn, the comment view opens and closes immediately on each click). Thus, I changed the event listener so that the logic for the "close" event listener triggers before the open logic(and thus the close logic won't run since the comment view is still marked as closed).  

**Notes/Disclaimer:**
The same issue is also solved by trying to close the comment view on "mousedown"(when the mouse is pressed) instead of on "click" (when the mouse is released). In between sprint 2 and 3, the code was changed from on "click" to on "mousedown" (not sure if it was changed for a different reason or to solve the same issue).  I changed it back to on "click" and fixed it differently, as I think it makes more sense for the comment views to open when a user releases a click, not when they press down (also, using on mouse down also seemed to be too "abrupt" of a ui change). Thoughts on which is better?
tldr: the issue was already fixed differently , but this fix might be "better"?

**Testing**
I tested locally by ensuring comment view would open properly. 

