### PR TITLE
DEV-171: Correct default version year and term for Fall 2023

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -88,7 +88,7 @@ const Form: FC<{
       dispatch(
         updateSearchFilters({ filter: 'year', value: date.getFullYear() + 1 }),
       );
-    else if (semester === 'Fall' && date.getMonth() < 3) {
+    else if (semester === 'Fall' && date.getMonth() < 2) {
       dispatch(
         updateSearchFilters({ filter: 'year', value: date.getFullYear() - 1 }),
       );


### PR DESCRIPTION
## Description
When users are trying to add courses for Fall 2023, the version year does not include 2023 and the default term is not set to Fall 2023.
![image](https://user-images.githubusercontent.com/77957751/228107600-b3d0da41-8e04-4a24-8433-c0cc766a3f82.png)

## Implementation
In Form.tsx line 91, change ``date.getMonth() < 3`` to ``date.getMonth() < 2``. The purpose of this change is to ensure that the year value for Fall 2023 is not mistakenly reduced to 2022 in cases where the code executes in March 2023. This can happen because the expression "date.getMonth()" will return 2 for March, and Fall 2023 courses were rolled out during that month.

## Testing
I tested locally and ensured that the default year value and term were correct.