### PR TITLE
DEV-124 fix three dots for every year to now open the popup menus

### DIFF
--- a/lib/components/dashboard/course-list/YearComponent.tsx
+++ b/lib/components/dashboard/course-list/YearComponent.tsx
@@ -119,8 +119,9 @@ const YearComponent: FC<{
       if (currentWrapperRef && !currentWrapperRef.contains(e.target))
         setDisplay(false);
     };
-    document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
+    document.addEventListener('click', handleClickOutside, true);
+    return () =>
+      document.removeEventListener('click', handleClickOutside, true);
   }, [wrapperRef, display]);
 
   /**


### PR DESCRIPTION
**Description**
When clicking on the three dots on the year component, a popup with options to remove and rename year or select terms should open. 

**Implementation**
In YearComponent.tsx, I added true to two event listeners in the useEffect that is handling the handleClickOutside. 

**Testing**
Tested locally.