### PR TITLE
DEV-158: Add loading logo to cart search in tracker

### DIFF
--- a/lib/components/popups/course-search/Cart.tsx
+++ b/lib/components/popups/course-search/Cart.tsx
@@ -36,6 +36,7 @@ const Cart: FC<{}> = () => {
   const [selectedRequirement, setSelectedRequirement] =
     useState<requirements>(emptyRequirements);
   const [cartFilter, setCartFilter] = useState<string>('');
+  const [isCartFilterLoaded, setIsCartFilterLoaded] = useState<boolean>(false);
   const [textFilterInputValue, setTextFilterInputValue] = useState<string>('');
 
   // Redux selectors and dispatch
@@ -46,25 +47,27 @@ const Cart: FC<{}> = () => {
   const pageIndex = useSelector(selectPageIndex);
 
   useEffect(() => {
-    if (distrs[1] && distrs[1].length > 0) {
-      setSelectedRequirement(distrs[1][0]);
-      setCartFilter(selectedRequirement.expr);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [distrs, currentPlanCourses, cartAdd]);
-
-  useEffect(() => {
     setCartFilter(selectedRequirement.expr);
     dispatch(updatePageIndex(0));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRequirement]);
 
+  useEffect(() => {
+    if (distrs[1] && distrs[1].length > 0) {
+      setSelectedRequirement(distrs[1][0]);
+      setCartFilter(distrs[1][0].expr);
+      setIsCartFilterLoaded(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [distrs, currentPlanCourses, cartAdd]);
+
   // Performing searching in useEffect so as to activate searching
   useEffect(() => {
     setSearching(true);
-    cartSearch();
+    dispatch(updateRetrievedCourses([]));
+    if (isCartFilterLoaded) cartSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cartFilter, pageIndex]);
+  }, [cartFilter, pageIndex, isCartFilterLoaded]);
 
   const cartSearch = () => {
     fineReqFind(cartFilter, pageIndex).then((courses: SISRetrievedCourse[]) => {


### PR DESCRIPTION
## Description
There was no loading icon displayed when users first open the fine requirement list in the tracker or switch between different fine requirements.

## Implementation
The problem occurred when users switched to a new fine requirement because the `RetrievedCourses` was not being emptied. As a result, the condition `courses.length > 0` in line 139 of CartCourseList.tsx always evaluated to true and prevented `getLoadingUI()` from being rendered. To fix the problem, I added `dispatch(updateRetrievedCourses([]));` in Cart.tsx line 67. 

Another issue was that `cartSearch()` was being executed before `cartFilter` had been fully loaded, causing all JHU courses to be loaded initially when users opened the fine requirement list. To resolve this issue, I introduced a state variable `isCartFilterLoaded`, and modified the code so that `cartSearch()` is only executed if `isCartFilterLoaded` is true.

## Testing
I tested locally and ensured everything works as expected.