### PR TITLE
Fix Issue with fine requirements not turning green after being fulfilled

### DIFF
--- a/lib/components/popups/course-search/cart/FineRequirementItem.tsx
+++ b/lib/components/popups/course-search/cart/FineRequirementItem.tsx
@@ -19,15 +19,15 @@ const FineRequirementListItem: FC<{
   return (
     <div
       className={clsx(
-        props.selected ? 'bg-secondary bg-opacity-25' : 'bg-white',
+        props.selected
+          ? 'bg-secondary bg-opacity-25'
+          : props.itemRequirement.required_credits > 0 &&
+            props.itemRequirement.fulfilled_credits > 0 &&
+            props.itemRequirement.fulfilled_credits >=
+              props.itemRequirement.required_credits
+          ? 'bg-green-100'
+          : 'bg-white',
         'mb-2 p-2 w-full h-auto rounded cursor-pointer transition duration-200 ease-in-out',
-        {
-          'bg-green-100':
-            props.itemRequirement.required_credits > 0
-              ? props.itemRequirement.fulfilled_credits >=
-                props.itemRequirement.required_credits
-              : props.itemRequirement.fulfilled_credits > 0,
-        },
       )}
       onClick={handleFineReqClick}
     >


### PR DESCRIPTION
Description: Some distributions might consist of more than one fine requirement. Each of the fine requirements are displayed in the Cart feature of the application. This Pull Request fixes a problem with the background of the fine requirement not turning green after it has been satisfied. This is an important bug to fix because it improves readbaility and user-friendliness as the user knows exactly which requirements they still need to fulfill.

Implementation: The problem here seemed to be that we originally had an isSelected prop for each fineRequirementItem which was marked as selected when clicked on. Otherwise, its background was set to white. This css property overwrote the color change which should have been produced after the requirement was completed. Simply moving everything into a single control flow chain fixed the issue. As described using the pseudocode below, this is how the functionality now works:

if (fine requirement item is selected) {
     Set background color to bg-secondary
} else {
     if (requirement is satisfied) {
          Set background color to bg-green-100
     } else {
          Set background color to bg-white
     }
}

Testing: This bug has been confirmed as resolved. When adding one or more courses that satisfy a fine requirement, the background of the fine requirement turns green as expected.