### PR TITLE
DEV-157: Prevent users from duplicating courses through drag and drop

### DIFF
--- a/lib/components/dashboard/course-list/CourseList.tsx
+++ b/lib/components/dashboard/course-list/CourseList.tsx
@@ -244,8 +244,11 @@ const CourseList: FC<Props> = ({ mode }) => {
     // handle error
     if (!res.ok) {
       if (res.status === 400) {
-        toast.error("Course isn't usually held this semester!", {
-          toastId: 'no course this semester',
+        const data = await res.json();
+        data.errors.forEach((error) => {
+          if (error.status === 400) {
+            toast.error(error.detail);
+          }
         });
       }
       console.log('ERROR:', res);


### PR DESCRIPTION
## Description
Drag and drop duplicate course should not be allowed.

## Implementation
- In the backend, I have implemented a new check to identify any duplicate courses that may arise after drag and drop. If any duplicates are found, corresponding errors will be thrown. 
- In the frontend, I have updated the toast message to reflect the errors that are being thrown.

## Testing
I tested locally and ensured everything works as expected.