### PR TITLE
DEV-104: opening comments no longer makes year scrollable

### DIFF
--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -476,7 +476,7 @@ const Semester: FC<{
           onMouseEnter={() => setHovered(true)}
           className="min-w-[15rem] max-w-[40rem] w-min mx-3"
         >
-          <div className="relative">
+          <div>
             <Comments
               location={'Semester ' + semesterYear._id + semesterName}
               hovered={hovered}


### PR DESCRIPTION
**Description:** 
Clicking on a comment for a semester no longer makes the year scrollable.

**Implementation:**
The comment that popups when clicking on a semester(which is within the year component) used to have the "relative" tag, but it no longer does so that the comment popup shows up a layer "above" of the year component instead of needing to scroll on the year to see the full comment.

**Testing:**
I tested locally by opening comments and making sure the comment shows up over the year.

What used to happen:
<img width="962" alt="image-20221210-214121" src="https://user-images.githubusercontent.com/123839928/230746526-c52e2366-5bba-404e-ac00-0e05cca169e8.png">

What happens now:
<img width="1388" alt="Screen Shot 2023-04-08 at 7 19 27 PM" src="https://user-images.githubusercontent.com/123839928/230746533-f3d8392c-508d-4672-a5c2-4ac129ff8e24.png">



