### PR TITLE
IN-70 data analytics fixes

### DIFF
--- a/pages/login/[[...token]].tsx
+++ b/pages/login/[[...token]].tsx
@@ -69,6 +69,8 @@ const Login: React.FC = () => {
    * @param token the token to set the cookie as
    */
   const handleDBLogin = (loginId: string) => {
+    amplitude.init('6beab2d293835bee5dd3417a83d9ac13', loginId);
+    amplitude.track('JHU User Login');
     userService
       .login(loginId)
       .then((data) => {
@@ -133,8 +135,6 @@ const Login: React.FC = () => {
    * Handles JHU Login button being pressed.
    */
   const handleJHULogin = (loginId: any) => {
-    amplitude.init('6beab2d293835bee5dd3417a83d9ac13', loginId);
-    amplitude.track('JHU User Login');
     if (window.location.href.includes('ucredit.me')) {
       if (loginId && typeof loginId === 'string') handleDBLogin(loginId);
       else window.location.href = getAPI(window) + '/login';
@@ -148,6 +148,11 @@ const Login: React.FC = () => {
    * @param id - id of the dev to login as
    */
   const handleDevLogin = (id: string) => (): void => {
+    amplitude.init('6beab2d293835bee5dd3417a83d9ac13', id);
+    if (id === 'TEST_DEV' || id === 'REVIEWER_DEV') {
+      amplitude.setOptOut(true);
+    }
+    amplitude.track('Dev User Login');
     axios
       .get(getAPI(window) + '/backdoor/verification/' + id)
       .then((res) => {


### PR DESCRIPTION
### description
based on the data in amplitude, even after amplitude tracking was merged into production, it seems we are still only tracking dev users. also, since dev user accounts are "staff" and "freshman", this makes the data confusing to interpret.  
![image](https://user-images.githubusercontent.com/43786620/232337689-1c370e18-1b45-46a5-9126-09fca19bf6f2.png)
![image](https://user-images.githubusercontent.com/43786620/232337604-99cb5386-1d78-4627-a711-4357ad7341a5.png)

### implementation
in [[...token]].tsx i moved the amplitude tracking from handleJHULogin to handleDevLogin (dev user login) and handleDBLogin (jhu user login). 
in amplitude, i added another event "dev user login" in addition to "guest user login" and "jhu user login" to hopefully make things more clear. 
i also opted "TEST_DEV" and "REVIEWER_DEV" out of tracking because currently their volume of data in amplitude is super high. 

### notes
i'm hoping this can get merged into production as soon as possible! and if everything goes well in amplitude i will finally migrate from test project to development and production projects. 