### PR TITLE
DEV-188 deleting last comment in thread doesn't delete that thread

### DIFF
--- a/lib/components/dashboard/Comments.tsx
+++ b/lib/components/dashboard/Comments.tsx
@@ -265,11 +265,14 @@ const Comments: FC<{
               .indexOf(comment_id);
             thread.comments.splice(commentIndex, 1);
             dispatch(updateThreads(threads.data.data));
+            await userService.removeComment(comment_id, token);
             break;
           }
         }
+        if (thread.comments.length === 0) {
+          await userService.removeThread(thread._id, token);
+        }
       }
-      await userService.removeComment(comment_id, token);
     } catch (err) {
       console.log(err);
     }

--- a/lib/services/user.service.ts
+++ b/lib/services/user.service.ts
@@ -116,6 +116,12 @@ const removeComment = (comment_id: string, token: string, cb = undefined) => {
     .then((res) => handleResponse(res, cb));
 };
 
+const removeThread = (thread_id: string, token: string, cb = undefined) => {
+  return fetchWrapper
+    .delete(`${getAPI(window)}/thread`, token, { thread_id })
+    .then((res) => handleResponse(res, cb));
+};
+
 const changeReviewStatus = (
   review_id,
   status,
@@ -162,6 +168,7 @@ export const userService = {
   getThreads,
   postNewComment,
   removeComment,
+  removeThread,
   changeReviewStatus,
   getNotifications,
 };


### PR DESCRIPTION
### description
currently, deleting the last comment in a comment thread does not delete that corresponding comment thread

### implementation
created removeThread in user.service.ts; in comments.tsx, when deleting comment, check if thread is empty and if so, call removeThread

### testing
tested locally