### PR TITLE
DEV-56 fix default major issue when changing between plans, adding/deleting majors, or adding/deleting the courses

### DIFF
--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -8,8 +8,10 @@ import { allMajors } from '../../resources/majors';
 import Tooltip from '@mui/material/Tooltip';
 import {
   selectPlan,
+  selectSelectedMajor,
   updateSelectedPlan,
   updateCurrentPlanCourses,
+  updateSelectedMajor,
 } from '../../slices/currentPlanSlice';
 import {
   updateAddingPlanStatus,
@@ -45,6 +47,7 @@ const majorOptions = allMajors.map((major) => ({
 const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
   const planList = useSelector(selectPlanList);
   const currentPlan = useSelector(selectPlan);
+  const newSelectedMajor = useSelector(selectSelectedMajor);
   const user = useSelector(selectUser);
   const token = useSelector(selectToken);
   const dispatch = useDispatch();
@@ -170,6 +173,11 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
       if (currentPlan.majors.includes(major.name))
         currentMajorOptions.push({ label: major.name, value: major.abbrev });
     });
+    if (newSelectedMajor) {
+      if (currentPlan.majors.includes(newSelectedMajor.degree_name)) {
+        dispatch(updateSelectedMajor(newSelectedMajor));
+      }
+    }
     return currentMajorOptions;
   };
 

--- a/lib/components/popups/DeleteCoursePopup.tsx
+++ b/lib/components/popups/DeleteCoursePopup.tsx
@@ -7,7 +7,12 @@ import {
 } from '../../slices/userSlice';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { selectPlan, updateSelectedPlan } from '../../slices/currentPlanSlice';
+import {
+  selectPlan,
+  updateSelectedPlan,
+  selectSelectedMajor,
+  updateSelectedMajor,
+} from '../../slices/currentPlanSlice';
 import { getAPI } from '../../resources/assets';
 import { Plan } from '../../resources/commonTypes';
 import {
@@ -29,6 +34,7 @@ const DeleteCoursePopup: FC = () => {
   const courseInfo = useSelector(selectCourseToDelete);
   const planList = useSelector(selectPlanList);
   const token = useSelector(selectToken);
+  const newSelectedMajor = useSelector(selectSelectedMajor);
 
   /**
    * Popup for deleting current selected course.
@@ -55,6 +61,9 @@ const DeleteCoursePopup: FC = () => {
           toastId: 'course deleted',
         });
         dispatch(updateSelectedPlan(newPlan));
+        if (newSelectedMajor) {
+          dispatch(updateSelectedMajor(newSelectedMajor));
+        }
         dispatch(
           updatePlanList(
             planList.map((plan) => {

--- a/lib/components/popups/course-search/search-results/CourseDisplay.tsx
+++ b/lib/components/popups/course-search/search-results/CourseDisplay.tsx
@@ -22,9 +22,11 @@ import {
   selectCurrentPlanCourses,
   selectPlan,
   selectTotalCredits,
+  selectSelectedMajor,
   updateCurrentPlanCourses,
   updateSelectedPlan,
   updateTotalCredits,
+  updateSelectedMajor,
 } from '../../../../slices/currentPlanSlice';
 import { getAPI } from '../../../../resources/assets';
 import SisCourse from './SisCourse';
@@ -46,6 +48,7 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
   const currentCourses = useSelector(selectCurrentPlanCourses);
   const totalCredits = useSelector(selectTotalCredits);
   const token = useSelector(selectToken);
+  const newSelectedMajor = useSelector(selectSelectedMajor);
 
   // component state setup
   const [inspectedArea, setInspectedArea] = useState<string>('None');
@@ -152,6 +155,11 @@ const CourseDisplay: FC<{ cart: boolean }> = ({ cart }) => {
         newPlanList[i] = newPlan;
       }
     }
+
+    if (newSelectedMajor) {
+      dispatch(updateSelectedMajor(newSelectedMajor));
+    }
+
     dispatch(updatePlanList(newPlanList));
     dispatch(updateTotalCredits(totalCredits + newUserCourse.credits));
     toast.success(version.title + ' added!', {


### PR DESCRIPTION
**Description**
A continuation of unresolved PR for DEV-46. The previous way to fix the issue triggers a new problem when adding/deleting majors and changing between plans. Now when the deleted major is the selected major for degree progress, the major in degree progress would not timely update the selected major. Similar situation occurs when changing between plan: the selected major for degree progress remains the same for different plans, even though the new plan doesn't contain the selected major for old plan.

**Implementation**
In CourseDisplay.tsx, DeleteCoursePopup.tsx, and Actionbar.tsx, add a segment of code to dispatch(updateSelectedMajor) after the dispatch(updateSelectedPlan). That is to override the "default-to-first-major" behavior set in updateSelectedPlan. 

**Testing**
Tested locally. Tested with a plan that has 2 majors: B.S. CS and AMS. While the default major is CS, when changing the selected major in degree progress to AMS, it maintains to be the selected major, even after adding/deleting a 3rd major (IS). After changing between the plans, AMS would still be the selected major. When deleting AMS as a major, the selected major will then jump back to CS. 