### PR TITLE
DEV-193: Make API call when search filters are changed

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -105,20 +105,6 @@ const Form: FC<{
 
   // Search with debouncing of 4/8s of a second.
   useEffect(() => {
-    // Skip searching if no filters or queries are specified
-    if (
-      searchTerm.length === 0 &&
-      searchFilters.credits === null &&
-      searchFilters.distribution === null &&
-      searchFilters.wi === null &&
-      searchFilters.department === null &&
-      searchFilters.tags === null &&
-      searchFilters.levels === null
-    ) {
-      dispatch(updateRetrievedCourses([]));
-      setSearching(false);
-      return;
-    }
     // Search params.
     const extras: SearchExtras = {
       page: pageIndex,

--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -139,13 +139,10 @@ const Form: FC<{
     setSearching(true);
     dispatch(updateRetrievedCourses([]));
 
-    if (searchTerm.length > 0) {
-      // Search with half second debounce.
-      const search = setTimeout(performSmartSearch(extras), 500);
-      return () => clearTimeout(search);
-    } else {
-      setSearching(false);
-    }
+    // Search with half second debounce.
+    const search = setTimeout(performSmartSearch(extras), 500);
+    return () => clearTimeout(search);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchTerm, searchFilters, pageIndex]);
 


### PR DESCRIPTION
## Description
API call should be made when search filters are changed in advanced course search.

## Implementation
Remove the `if (searchTerm.length > 0)` check in `lib/components/popups/course-search/query-components/Form.tsx`

## Testing
I tested locally and ensured everything works as expected.