### PR TITLE
DEV-183: Filter results of search form by Upper/Lower level 

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -24,8 +24,6 @@ import { selectPlan } from '../../../../slices/currentPlanSlice';
 
 /**
  * Search form, including the search query input and filters.
- * TODO: filter by uppeer/lower levels
- *
  * @prop setSearching - sets searching state
  */
 const Form: FC<{


### PR DESCRIPTION
**Description:** Need to resolve comment saying filtering course search results by upper and lowel level is still TODO.

**Implementation:** FIltering by course search results by upper and lower level already seems to be implemented, so I deleted the TODO comment.

**Testing:**Tested locally and on ucredit.me to make sure filtering by upper and lower level courses works.