### PR TITLE
Dev 184: Implement Filter by Recently Updated 

### DIFF
--- a/lib/components/popups/course-search/query-components/Form.tsx
+++ b/lib/components/popups/course-search/query-components/Form.tsx
@@ -24,8 +24,6 @@ import { selectPlan } from '../../../../slices/currentPlanSlice';
 
 /**
  * Search form, including the search query input and filters.
- * TODO: filter by uppeer/lower levels
- *
  * @prop setSearching - sets searching state
  */
 const Form: FC<{

--- a/lib/components/reviewer/Search.tsx
+++ b/lib/components/reviewer/Search.tsx
@@ -98,7 +98,6 @@ const Search: React.FC<{
       filteredArray.push({ reviewee: JSON.parse(k), plans: v });
     switch (searchSetting) {
       case 'Recently Updated':
-        // TODO
         filteredArray.sort((a, b) => 
           -1*getLastUpdatedPlan(a).localeCompare(getLastUpdatedPlan(b)),
         );

--- a/lib/components/reviewer/Search.tsx
+++ b/lib/components/reviewer/Search.tsx
@@ -65,9 +65,8 @@ const Search: React.FC<{
     });
     if (lastUpdatedPlan.updatedAt == null) {
       return '';
-    } else {
-      return lastUpdatedPlan.updatedAt.toLocaleString();
     }
+    return lastUpdatedPlan.updatedAt.toLocaleString();
   };
 
   const getUpdateTime = (a: StatusPlan) => {

--- a/lib/components/reviewer/Search.tsx
+++ b/lib/components/reviewer/Search.tsx
@@ -4,6 +4,7 @@ import debounce from 'lodash.debounce';
 import {
   RevieweePlans,
   ReviewRequestStatus,
+  StatusPlan,
 } from '../../../lib/resources/commonTypes';
 import Status from './Status';
 import React from 'react';
@@ -69,6 +70,13 @@ const Search: React.FC<{
     }
   };
 
+  const getUpdateTime = (a: StatusPlan) => {
+    if (a.updatedAt === undefined) {
+      return '';
+    }
+    return a.updatedAt.toLocaleString();
+  };
+
   const filter = () => {
     let filteredMap = new Map();
     for (const { reviewee, plans } of revieweePlans) {
@@ -94,6 +102,16 @@ const Search: React.FC<{
       filteredArray.push({ reviewee: JSON.parse(k), plans: v });
     switch (searchSetting) {
       case 'Recently Updated':
+        let multiplier = -1;
+        if (reversed) {
+          multiplier = 1;
+        }
+        filteredArray.forEach((a) =>
+          a.plans.sort(
+            (b, c) =>
+              multiplier * getUpdateTime(b).localeCompare(getUpdateTime(c)),
+          ),
+        );
         filteredArray.sort(
           (a, b) =>
             -1 * getLastUpdatedPlan(a).localeCompare(getLastUpdatedPlan(b)),
@@ -125,7 +143,9 @@ const Search: React.FC<{
         break;
       default:
     }
-    if (reversed) filteredArray = filteredArray.reverse();
+    if (reversed) {
+      filteredArray = filteredArray.reverse();
+    }
     setFiltered(filteredArray || []);
   };
 

--- a/lib/components/reviewer/Search.tsx
+++ b/lib/components/reviewer/Search.tsx
@@ -48,27 +48,23 @@ const Search: React.FC<{
   };
 
   //Given a reviewee, returns time of last update of one of that reviewees plans, if that info is tracked
-  const getLastUpdatedPlan= (a:RevieweePlans) => {
-    let lastUpdatedPlan=a.plans[0];
-    a.plans.forEach(d => {
-      if(lastUpdatedPlan.updatedAt!==undefined && d.updatedAt!==undefined)
-      {
-        if(lastUpdatedPlan.updatedAt < d.updatedAt)
-        {
-          lastUpdatedPlan=d;
+  const getLastUpdatedPlan = (a: RevieweePlans) => {
+    let lastUpdatedPlan = a.plans[0];
+    a.plans.forEach((d) => {
+      if (
+        lastUpdatedPlan.updatedAt !== undefined &&
+        d.updatedAt !== undefined
+      ) {
+        if (lastUpdatedPlan.updatedAt < d.updatedAt) {
+          lastUpdatedPlan = d;
         }
+      } else if (d.updatedAt != null) {
+        lastUpdatedPlan = d;
       }
-      else if(d.updatedAt!=null)
-      {
-        lastUpdatedPlan=d;
-      }
-    } );
-    if(lastUpdatedPlan.updatedAt==null)
-    {
-      return "";
-    }
-    else
-    {
+    });
+    if (lastUpdatedPlan.updatedAt == null) {
+      return '';
+    } else {
       return lastUpdatedPlan.updatedAt.toLocaleString();
     }
   };
@@ -98,8 +94,9 @@ const Search: React.FC<{
       filteredArray.push({ reviewee: JSON.parse(k), plans: v });
     switch (searchSetting) {
       case 'Recently Updated':
-        filteredArray.sort((a, b) => 
-          -1*getLastUpdatedPlan(a).localeCompare(getLastUpdatedPlan(b)),
+        filteredArray.sort(
+          (a, b) =>
+            -1 * getLastUpdatedPlan(a).localeCompare(getLastUpdatedPlan(b)),
         );
         break;
       case 'First Name':

--- a/lib/components/reviewer/Search.tsx
+++ b/lib/components/reviewer/Search.tsx
@@ -47,6 +47,32 @@ const Search: React.FC<{
     updateSearchState(e.target.value);
   };
 
+  //Given a reviewee, returns time of last update of one of that reviewees plans, if that info is tracked
+  const getLastUpdatedPlan= (a:RevieweePlans) => {
+    let lastUpdatedPlan=a.plans[0];
+    a.plans.forEach(d => {
+      if(lastUpdatedPlan.updatedAt!==undefined && d.updatedAt!==undefined)
+      {
+        if(lastUpdatedPlan.updatedAt < d.updatedAt)
+        {
+          lastUpdatedPlan=d;
+        }
+      }
+      else if(d.updatedAt!=null)
+      {
+        lastUpdatedPlan=d;
+      }
+    } );
+    if(lastUpdatedPlan.updatedAt==null)
+    {
+      return "";
+    }
+    else
+    {
+      return lastUpdatedPlan.updatedAt.toLocaleString();
+    }
+  };
+
   const filter = () => {
     let filteredMap = new Map();
     for (const { reviewee, plans } of revieweePlans) {
@@ -73,6 +99,9 @@ const Search: React.FC<{
     switch (searchSetting) {
       case 'Recently Updated':
         // TODO
+        filteredArray.sort((a, b) => 
+          -1*getLastUpdatedPlan(a).localeCompare(getLastUpdatedPlan(b)),
+        );
         break;
       case 'First Name':
         filteredArray.sort((a, b) =>

--- a/lib/resources/commonTypes.tsx
+++ b/lib/resources/commonTypes.tsx
@@ -101,6 +101,7 @@ export type Plan = {
   numYears: number;
   years: Year[];
   reviewers: any[];
+  updatedAt: Date;
 };
 
 type Affiliation = 'STUDENT' | 'FACULTY' | 'STAFF';


### PR DESCRIPTION
**Description:** 
On Reviewee Dashboard, we want reviewees to be able to filter their reviewee's plans by recently updated plans.

**Implementation:** 
In corresponding backend PR, mongoDB starts tracking timestamps whenever a plan is updated. Since mongoDB doesn't have timestamps for old plans(it starts tracking them whenever a course is added/removed from an old plan), those plans are "last" in the sorted order(their timestamps are just an empty string). In order to sort by most recently updated plan, we find the last updated time among all plans for each reviewee, and sort reviewees based on that time.

**Testing:** 
Tested locally by updating plans and making sure reviewer dashboard updates appropriately. 