### PR TITLE
Dev-177: Remove Import for Dummy Courses from CartCourseList.tsx

### DIFF
--- a/lib/components/popups/course-search/Cart.tsx
+++ b/lib/components/popups/course-search/Cart.tsx
@@ -172,6 +172,7 @@ const Cart: FC<{}> = () => {
 
           <div
             className={
+              // todo: check styles?
               'flex flex-col rounded-l bg-gray-200 flex-none border-l-2 tight:border-0 border-gray-300 tight:w-auto w-80'
             }
           >

--- a/lib/components/popups/course-search/Cart.tsx
+++ b/lib/components/popups/course-search/Cart.tsx
@@ -172,7 +172,6 @@ const Cart: FC<{}> = () => {
 
           <div
             className={
-              // todo: check styles?
               'flex flex-col rounded-l bg-gray-200 flex-none border-l-2 tight:border-0 border-gray-300 tight:w-auto w-80'
             }
           >

--- a/lib/components/popups/course-search/cart/CartCourseList.tsx
+++ b/lib/components/popups/course-search/cart/CartCourseList.tsx
@@ -13,7 +13,6 @@ import ReactPaginate from 'react-paginate';
 import { QuestionMarkCircleIcon } from '@heroicons/react/solid';
 import { Course } from '../../../../resources/commonTypes';
 
-
 /*
   List of searched courses.
 */
@@ -51,8 +50,7 @@ const CartCourseList: FC<{
           key={inspecting.number}
           className="transition duration-200 ease-in transform hover:scale-105"
           onClick={() => setHideResults(true)}
-        >
-        </div>,
+        ></div>,
       );
     }
     return toDisplay;

--- a/lib/components/popups/course-search/cart/CartCourseList.tsx
+++ b/lib/components/popups/course-search/cart/CartCourseList.tsx
@@ -13,8 +13,6 @@ import ReactPaginate from 'react-paginate';
 import { QuestionMarkCircleIcon } from '@heroicons/react/solid';
 import { Course } from '../../../../resources/commonTypes';
 
-// TODO: remove this import, for dummy courses
-import CartCourseListItem from './CartCourseListItem';
 
 /*
   List of searched courses.
@@ -54,7 +52,6 @@ const CartCourseList: FC<{
           className="transition duration-200 ease-in transform hover:scale-105"
           onClick={() => setHideResults(true)}
         >
-          <CartCourseListItem course={inspecting} version={0} />
         </div>,
       );
     }


### PR DESCRIPTION
**Decription:**
There is a comment "Todo: remove this (CourseListItem) import for dummy courses" in CartCourseList.tsx. 

**Testing:**
With the import and corresponding "CourseListItem" part removed, there is no effect to the searching of the courses. 