### PR TITLE
DEV-71: changing term in course view is reflected on dashboard

### DIFF
--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -118,33 +118,33 @@ const CourseDisplayPopup: FC = () => {
         dispatch(updateInspectedVersion(placeholderCourse));
       }
     }
+    console.log("course", courseToShow);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Gets current year name.
-  const getYear = (newPlan: Plan): Year | null => {
+  const getYear = (newPlan: Plan, year_id: string): Year | null => {
     let out: Year | null = null;
-    if (courseToShow !== null) {
-      newPlan.years.forEach((planYear) => {
-        if (planYear._id === courseToShow.year_id) {
-          out = planYear;
-        }
-      });
-    }
+    newPlan.years.forEach((planYear) => {
+      if (planYear._id === year_id) {
+        out = planYear;
+      }
+    });
     return out;
   };
 
   // Updates distribution bars upon successfully adding a course.
-  const addCourse = (plan?: Plan): void => {
+  const addCourse = (plan?: Plan, year_id?: string, term?: string): void => {
     if (version !== 'None' && courseToShow !== null && plan !== undefined) {
-      const addingYear: Year | null = getYear(plan);
+      const addingYear: Year | null = getYear(plan, year_id || courseToShow.year_id);
+      console.log("year", addingYear);     
       const body = {
         user_id: user._id,
-        year_id: courseToShow.year_id !== null ? courseToShow.year_id : '',
+        year_id: addingYear !== null ? addingYear._id : '',
         plan_id: plan._id,
         title: version.title,
         year: addingYear !== null ? addingYear.name : '',
-        term: courseToShow.term,
+        term: term || courseToShow.term,
         credits: version.credits === '' ? 0 : version.credits,
         distribution_ids: plan.distribution_ids,
         isPlaceholder: placeholder,
@@ -158,6 +158,7 @@ const CourseDisplayPopup: FC = () => {
         level: version.level,
         expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       };
+      console.log(body);
       fetch(getAPI(window) + '/courses', {
         method: 'POST',
         headers: {
@@ -178,6 +179,7 @@ const CourseDisplayPopup: FC = () => {
       let newUserCourse: UserCourse;
       if (data.errors === undefined && courseToShow !== null) {
         newUserCourse = { ...data.data };
+        console.log("created course", newUserCourse);
         dispatch(updateCurrentPlanCourses([...currentCourses, newUserCourse]));
         const allYears: Year[] = [...plan.years];
         const newYears: Year[] = [];

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -118,7 +118,6 @@ const CourseDisplayPopup: FC = () => {
         dispatch(updateInspectedVersion(placeholderCourse));
       }
     }
-    console.log("course", courseToShow);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -136,8 +135,10 @@ const CourseDisplayPopup: FC = () => {
   // Updates distribution bars upon successfully adding a course.
   const addCourse = (plan?: Plan, year_id?: string, term?: string): void => {
     if (version !== 'None' && courseToShow !== null && plan !== undefined) {
-      const addingYear: Year | null = getYear(plan, year_id || courseToShow.year_id);
-      console.log("year", addingYear);     
+      const addingYear: Year | null = getYear(
+        plan,
+        year_id || courseToShow.year_id,
+      );
       const body = {
         user_id: user._id,
         year_id: addingYear !== null ? addingYear._id : '',
@@ -178,7 +179,6 @@ const CourseDisplayPopup: FC = () => {
       let newUserCourse: UserCourse;
       if (data.errors === undefined && courseToShow !== null) {
         newUserCourse = { ...data.data };
-        console.log("created course", newUserCourse);
         dispatch(updateCurrentPlanCourses([...currentCourses, newUserCourse]));
         const allYears: Year[] = [...plan.years];
         const newYears: Year[] = [];

--- a/lib/components/popups/CourseDisplayPopup.tsx
+++ b/lib/components/popups/CourseDisplayPopup.tsx
@@ -158,7 +158,6 @@ const CourseDisplayPopup: FC = () => {
         level: version.level,
         expireAt: user._id === 'guestUser' ? Date.now() : undefined,
       };
-      console.log(body);
       fetch(getAPI(window) + '/courses', {
         method: 'POST',
         headers: {
@@ -215,7 +214,7 @@ const CourseDisplayPopup: FC = () => {
   const updateYears =
     (newYears: Year[], newUserCourse: UserCourse) =>
     (year: Year): void => {
-      if (courseToShow !== null && year._id === courseToShow.year_id) {
+      if (newUserCourse !== null && year._id === newUserCourse.year_id) {
         const yCourses = [...year.courses, newUserCourse];
         newYears.push({ ...year, courses: yCourses });
       } else {

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -22,7 +22,6 @@ import {
   updateCartAdd,
 } from '../../../../slices/searchSlice';
 import {
-  Course,
   Plan,
   ReviewMode,
   SemesterType,
@@ -75,7 +74,6 @@ const SisCourse: FC<{
   const token = useSelector(selectToken);
   const cartInvokedBySemester = useSelector(selectCartInvokedBySemester);
 
-  const [versionIndex, updateVersionIndex] = useState<number>(0);
   const [year, setYear] = useState<string>(
     courseToShow ? courseToShow.year_id : searchYear,
   );
@@ -88,16 +86,6 @@ const SisCourse: FC<{
     setOgSem(searchSemester);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    if (inspected !== 'None' && version !== 'None') {
-      const index: number = inspected.terms.indexOf(
-        JSON.stringify(version.term),
-      );
-      updateVersionIndex(index);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [version]);
 
   // Returns an array of select options for the distribution area users want to add the course to.
   const getInspectedAreas = () => {

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -79,16 +79,17 @@ const SisCourse: FC<{
   const [year, setYear] = useState<string>(courseToShow!.year_id);
   const [sem, setSem] = useState<string>(courseToShow!.term);
   const [ogSem, setOgSem] = useState<SemesterType | 'All'>('All');
-  
+
   useEffect(() => {
     setOgSem(searchSemester);
-    console.log('terms', inspected);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     if (inspected !== 'None' && version !== 'None') {
-      const index: number = inspected.terms.indexOf(JSON.stringify(version.term));
+      const index: number = inspected.terms.indexOf(
+        JSON.stringify(version.term),
+      );
       updateVersionIndex(index);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -385,13 +386,16 @@ const SisCourse: FC<{
     if (inspected === 'None') {
       return [];
     }
-    const offeredSemesters = [... new Set(inspected!.terms.map((term) => {
-      return term.split(' ')[0].toLowerCase();
-    }))]
-    console.log(offeredSemesters);
-    const terms: { year_id: string, semester?: string }[] = [];
+    const offeredSemesters = [
+      ...new Set(
+        inspected!.terms.map((term) => {
+          return term.split(' ')[0].toLowerCase();
+        }),
+      ),
+    ];
+    const terms: { year_id: string; semester?: string }[] = [];
     for (const year of currentPlan.years) {
-      if (year.name !== "AP/Transfer") {
+      if (year.name !== 'AP/Transfer') {
         for (const semester of offeredSemesters) {
           terms.push({ year_id: year._id, semester: semester });
         }
@@ -400,12 +404,12 @@ const SisCourse: FC<{
       }
     }
     return terms;
-  }
+  };
 
   const getTermString = (year_id: string, semester: string | undefined) => {
-    const year = currentPlan.years.find(y => y._id === year_id);
+    const year = currentPlan.years.find((y) => y._id === year_id);
     return (year ? year.name : '') + (semester ? ' ' + semester : '');
-  }
+  };
 
   return (
     <div className="flex flex-col h-full">
@@ -428,21 +432,14 @@ const SisCourse: FC<{
               </div>
             </div>
             <div className="flex flex-row items-center font-semibold">
-              <div className="flex flex-row">
-                Term
-                {/* <div className="flex-grow mt-1">
-                  <QuestionMarkCircleIcon
-                    className="h-4 fill-gray"
-                    data-tooltip-id="godtip"
-                    data-tooltip-html={`<p>This is a specific snapshot of course information at a specific time in the past or present.</p><p>NOTE: This is NOT to determine where on the plan you are adding the course.</p><p>(ie. Course Version "Spring, 2021" may not equal "Spring, Senior")</p>`}
-                  />
-                </div> */}
-                :
-              </div>
+              <div className="flex flex-row">Term :</div>
               <Select
                 className="ml-2 w-50"
                 options={getTerms().map((term) => {
-                  return { label: getTermString(term.year_id, term.semester), value: JSON.stringify(term) };
+                  return {
+                    label: getTermString(term.year_id, term.semester),
+                    value: JSON.stringify(term),
+                  };
                 })}
                 value={{
                   label: getTermString(year, sem),

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -405,7 +405,8 @@ const SisCourse: FC<{
 
   const getTermString = (year_id: string, semester: string | undefined) => {
     const year = currentPlan.years.find((y) => y._id === year_id);
-    return (year ? year.name : '') + (semester ? ' ' + semester : '');
+    const semesterFormatted = semester ? semester.charAt(0).toUpperCase() + semester.slice(1) : '';
+    return (year ? year.name : '') + ' ' + semesterFormatted;
   };
 
   return (

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -405,7 +405,9 @@ const SisCourse: FC<{
 
   const getTermString = (year_id: string, semester: string | undefined) => {
     const year = currentPlan.years.find((y) => y._id === year_id);
-    const semesterFormatted = semester ? semester.charAt(0).toUpperCase() + semester.slice(1) : '';
+    const semesterFormatted = semester
+      ? semester.charAt(0).toUpperCase() + semester.slice(1)
+      : '';
     return (year ? year.name : '') + ' ' + semesterFormatted;
   };
 

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -76,8 +76,12 @@ const SisCourse: FC<{
   const cartInvokedBySemester = useSelector(selectCartInvokedBySemester);
 
   const [versionIndex, updateVersionIndex] = useState<number>(0);
-  const [year, setYear] = useState<string>(courseToShow!.year_id);
-  const [sem, setSem] = useState<string>(courseToShow!.term);
+  const [year, setYear] = useState<string>(
+    courseToShow ? courseToShow.year_id : searchYear,
+  );
+  const [sem, setSem] = useState<string>(
+    courseToShow ? courseToShow.term : searchSemester.toLowerCase(),
+  );
   const [ogSem, setOgSem] = useState<SemesterType | 'All'>('All');
 
   useEffect(() => {
@@ -146,6 +150,13 @@ const SisCourse: FC<{
   // Handles switching displayed term.
   const handleTermSwitch = (event: any): void => {
     const value = JSON.parse(event.value);
+    dispatch(
+      updateSearchTime({
+        searchSemester:
+          value.semester.charAt(0).toUpperCase() + value.semester.slice(1),
+        searchYear: value.year_id,
+      }),
+    );
     setYear(value.year_id);
     setSem(value.semester);
   };
@@ -399,8 +410,6 @@ const SisCourse: FC<{
         for (const semester of offeredSemesters) {
           terms.push({ year_id: year._id, semester: semester });
         }
-      } else {
-        terms.push({ year_id: year._id });
       }
     }
     return terms;

--- a/lib/components/popups/course-search/search-results/SisCourse.tsx
+++ b/lib/components/popups/course-search/search-results/SisCourse.tsx
@@ -82,8 +82,7 @@ const SisCourse: FC<{
   
   useEffect(() => {
     setOgSem(searchSemester);
-    console.log("plan", currentPlan);
-    console.log("term", year);
+    console.log('terms', inspected);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -383,10 +382,17 @@ const SisCourse: FC<{
   );
 
   const getTerms = () => {
+    if (inspected === 'None') {
+      return [];
+    }
+    const offeredSemesters = [... new Set(inspected!.terms.map((term) => {
+      return term.split(' ')[0].toLowerCase();
+    }))]
+    console.log(offeredSemesters);
     const terms: { year_id: string, semester?: string }[] = [];
     for (const year of currentPlan.years) {
       if (year.name !== "AP/Transfer") {
-        for (const semester of ['fall', 'spring', 'summer', 'intersession']) {
+        for (const semester of offeredSemesters) {
           terms.push({ year_id: year._id, semester: semester });
         }
       } else {
@@ -438,21 +444,6 @@ const SisCourse: FC<{
                 options={getTerms().map((term) => {
                   return { label: getTermString(term.year_id, term.semester), value: JSON.stringify(term) };
                 })}
-                  /*inspected.terms
-                  .filter(
-                    (term) =>
-                      term
-                        .toLowerCase()
-                        .includes(searchSemester.toLowerCase()) ||
-                      (courseToShow !== null &&
-                        term
-                          .toLowerCase()
-                          .includes(courseToShow.term.toLowerCase())),
-                  )
-                  .map((term) => {
-                    return { label: term, value: term };
-                  })*/
-                // }
                 value={{
                   label: getTermString(year, sem),
                   value: JSON.stringify({ year_id: year, semester: sem }),


### PR DESCRIPTION
### Description
Addresses the user story (asked Sean about this and he added the below to the jira ticket):
As a user, after I look through a course’s description, I want to change the term of a course I’m taking (within the course view) and have it reflect in the dashboard, so that I don’t have to drag and drop when I have the ability to change the term in the course-specific view.
i.e. Term dropdown functionality has changed, it now reflects the semester that the user is taking the course, instead of the inspection version

### Implementation
- edited `SisCourse.tsx` so Term dropdown options are the years/semesters in a user's plan
- added state to store the selected year/semester that the course is to be updated to
- edited `addCourse` and `handleUpdate` methods in `CourseDisplayPopup.tsx` to take selected year/semester into account
- also made so that the dropdown allows you to change the semester that you're trying to add the course to 

### Testing
locally tested, tried a changing semester and changing year