### PR TITLE
Dev 168: Fix search features for Mol-Cell major

### DIFF
--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3790,7 +3790,6 @@ const minorCS: Minor = {
   ],
 };
 
-
 const bsMolCell: Major = {
   degree_name: 'B.S. Molecular and Cellular Biology',
   abbrev: 'B.S. Mol Cell',
@@ -3873,7 +3872,8 @@ const bsMolCell: Major = {
       min_credits_per_course: 1,
       description:
         'Must complete General Chemistry (or AP equivalent) and Organic Chemistry in addition to their respective labs.',
-      criteria: 'AS.030.101[C]^OR^AS.030.105[C]^OR^AS.030.102[C]^OR^AS.030.106[C]^OR^AS.030.103[C]^OR^AS.030.205[C]^OR^AS.030.206[C]^OR^AS.030.212[C]^OR^AS.030.225[C]^OR^AS.030.227[C]',
+      criteria:
+        'AS.030.101[C]^OR^AS.030.105[C]^OR^AS.030.102[C]^OR^AS.030.106[C]^OR^AS.030.103[C]^OR^AS.030.205[C]^OR^AS.030.206[C]^OR^AS.030.212[C]^OR^AS.030.225[C]^OR^AS.030.227[C]',
       double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
@@ -3921,7 +3921,8 @@ const bsMolCell: Major = {
       min_credits_per_course: 1,
       description:
         'Must complete Physics I and II (or AP equivalent) in addition to their respective labs.',
-      criteria: 'AS.171.101[C]^OR^AS.171.103[C]^OR^AS.171.107[C]^OR^AS.171.102[C]^OR^AS.171.104[C]^OR^AS.171.108[C]^OR^AS.173.111[C]^OR^AS.173.112[C]',
+      criteria:
+        'AS.171.101[C]^OR^AS.171.103[C]^OR^AS.171.107[C]^OR^AS.171.102[C]^OR^AS.171.104[C]^OR^AS.171.108[C]^OR^AS.173.111[C]^OR^AS.173.112[C]',
       double_count: [
         'Biology Research Requirement',
         'Writing Intensive',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3790,11 +3790,7 @@ const minorCS: Minor = {
   ],
 };
 
-/*
-  TODO:
-  1. Some of the search features don't work properly (i.e. research courses, General Physics II for bio majors)
-  3. Potentially formatting updates
-*/
+
 const bsMolCell: Major = {
   degree_name: 'B.S. Molecular and Cellular Biology',
   abbrev: 'B.S. Mol Cell',

--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3877,7 +3877,7 @@ const bsMolCell: Major = {
       min_credits_per_course: 1,
       description:
         'Must complete General Chemistry (or AP equivalent) and Organic Chemistry in addition to their respective labs.',
-      criteria: 'AS Chemistry[D]',
+      criteria: 'AS.030.101[C]^OR^AS.030.105[C]^OR^AS.030.102[C]^OR^AS.030.106[C]^OR^AS.030.103[C]^OR^AS.030.205[C]^OR^AS.030.206[C]^OR^AS.030.212[C]^OR^AS.030.225[C]^OR^AS.030.227[C]',
       double_count: [
         'Biology Research Requirement',
         'Writing Intensive',
@@ -3925,7 +3925,7 @@ const bsMolCell: Major = {
       min_credits_per_course: 1,
       description:
         'Must complete Physics I and II (or AP equivalent) in addition to their respective labs.',
-      criteria: 'AS Physics & Astronomy[D]',
+      criteria: 'AS.171.101[C]^OR^AS.171.103[C]^OR^AS.171.107[C]^OR^AS.171.102[C]^OR^AS.171.104[C]^OR^AS.171.108[C]^OR^AS.173.111[C]^OR^AS.173.112[C]',
       double_count: [
         'Biology Research Requirement',
         'Writing Intensive',


### PR DESCRIPTION
**Description**: Some of the search features for the mol-cell major do not work, namely clicking on some of the distributions did not result in the right courses showing up in the course search. 

**Implementation:** I changed the criteria under each distribution to match the course numbers of the fine requirements criteria instead of having department tags like "AS Chemistry" or "AS Physics".

**Testing:** Tested locally

Before:
<img width="1103" alt="Screen Shot 2023-05-18 at 6 45 10 PM" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/123839928/e331baa0-1a7d-48e4-8eee-a12790d450ab">

After:
<img width="1102" alt="Screen Shot 2023-05-18 at 7 18 47 PM" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/123839928/e8da2f7b-c665-4077-af79-1b13d93add4c">
