### PR TITLE
DEV-174: Added thread as a course prop

### DIFF
--- a/lib/components/dashboard/course-list/CourseComponent.tsx
+++ b/lib/components/dashboard/course-list/CourseComponent.tsx
@@ -38,7 +38,8 @@ const CourseComponent: FC<{
   year: Year;
   semester: SemesterType;
   mode: ReviewMode;
-}> = ({ setDraggable, year, course, semester, mode }) => {
+  thread: string
+}> = ({ setDraggable, year, course, semester, mode, thread }) => {
   // React setup
   const [activated, setActivated] = useState<boolean>(false);
   const [satisfied, setSatisfied] = useState<boolean>(false);

--- a/lib/components/dashboard/course-list/CourseDraggable.tsx
+++ b/lib/components/dashboard/course-list/CourseDraggable.tsx
@@ -22,7 +22,8 @@ const CourseDraggable: FC<{
   semesterYear: Year;
   semesterName: SemesterType;
   mode: ReviewMode;
-}> = ({ course, index, semesterYear, semesterName, mode }) => {
+  thread: string;
+}> = ({ course, index, semesterYear, semesterName, mode, thread }) => {
   const [draggable, setDraggable] = useState<boolean>(true);
   const [hovered, setHovered] = useState<boolean>(false);
   return (
@@ -58,6 +59,7 @@ const CourseDraggable: FC<{
                 course={course}
                 semester={semesterName}
                 mode={mode}
+                thread={thread}
               />
             </div>
           );

--- a/lib/components/dashboard/course-list/Semester.tsx
+++ b/lib/components/dashboard/course-list/Semester.tsx
@@ -138,7 +138,7 @@ const Semester: FC<{
               semesterName={semesterName}
               semesterYear={semesterYear}
               mode={mode}
-              // TODO: Add a thread prop here. Add a thread state in the course component.
+              thread={'Course ' + course._id}
               // When retrieving threads make sure the threads are stored as a map. We can then not add further complexity when searching for threads since map find is O(1) if we check them here.
             />
           </div>
@@ -154,6 +154,7 @@ const Semester: FC<{
               semester={semesterName}
               year={semesterYear}
               mode={mode}
+              thread={'Course ' + course._id}
             />
           </div>
         );


### PR DESCRIPTION
**Description:** There is a todo asking to add a thread prop to course components. This way, when opening a comment thread, instead of checking every thread to see if that one has the location of the one that should be opened, we can just open the thread associated with the course by checking this prop. Note, the actual implementation of that second part is under another todo/task(DEV-175) that I'd be happy to work on next time we have a sprint(or before summer starts).

**Implementation:** I added a thread state to the CourseComponent and CourseDraggable component. I passed in a "Course" + course.id prop to these components in Sem.tsx to represent the thread id(this is how the course threads locations/ids are identified as well), so the course can access the appropriate thread in O(1) time when necessary. 

**Testing:** Tested locally- I just added a state that won't be used yet so nothing should be changed. 

**Note:** The original todo comment is as follows:
// TODO: Add a thread prop here. Add a thread state in the course component.
// When retrieving threads make sure the threads are stored as a map. We can then not add further complexity when searching for threads since map find is O(1) if we check them here.
The todo was a little ambiguous, but I believe the reason for adding a state was to help with DEV-175 and just have appropriate thread referencers inside the course components as stated above, but I might have misinterpreted. Figured I'd add this here just in case you guys thought it meant something different.
I also did not delete the second comment as it might help with DEV-175(the todo like 5 lines above this one).
