### PR TITLE
DEV-79: let placeholder course name be any string

### DIFF
--- a/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
+++ b/lib/components/dashboard/degree-info/DistributionBarsJSX.tsx
@@ -194,7 +194,7 @@ const DistributionBarsJSX: FC<{ major: Major }> = ({ major }) => {
             counted = true;
         });
         checked.push(courseObj.resp);
-      } else if (course.number === 'placeholder') {
+      } else if (course.isPlaceholder === true) {
         const resp: Course = {
           title: '',
           number: course.number,


### PR DESCRIPTION
## problem 
when placeholder course number is placeholder, course updates distributions as expected. When placeholder course number is anything else like `EN.123.123`, distribution does not update after adding the placeholder. 

## solution 
remove faulty boolean check; let number be anything, not necessarily 'placeholder' 
Check with course.isPlaceholder 