### PR TITLE
DEV-CE: Add EN.601.104 as criteria for computer ethics fine requirement.

### DIFF
--- a/lib/resources/majors.tsx
+++ b/lib/resources/majors.tsx
@@ -3378,7 +3378,8 @@ const bsCS: Major = {
             'EN.601.124 The Ethics of Artificial Intelligence and Automation (The Ethics of Artificial Intelligence and Automation) <br /> ' +
             'EN.660.400 Practical Ethics for Future Leaders',
           required_credits: 1,
-          criteria: 'EN.600.104[C]^OR^EN.601.124[C]^OR^EN.660.400[C]',
+          criteria:
+            'EN.600.104[C]^OR^EN.601.104[C]^OR^EN.601.124[C]^OR^EN.660.400[C]',
         },
         {
           description:


### PR DESCRIPTION
Description: Bug reported by JJ where EN.601.104 was not being included in the criteria for the Computer Ethics fine requirement. This bug has now been resolved.


Implementation: Added EN.601.104 to the criteria string of the Computer Ethics fine requirement in majors.tsx.


Testing: Tested by adding the Computer Ethics course and it now satisfies the requirement.
