### PR TITLE
DEV-197 Red Error Icon & Green Check Icon in Tracker

### DIFF
--- a/lib/components/dashboard/degree-info/CourseBar.tsx
+++ b/lib/components/dashboard/degree-info/CourseBar.tsx
@@ -117,9 +117,9 @@ const CourseBar: FC<{
         <div className="truncate">{section}</div>
         <div>
           {remainingCredits === 0 && completed ? (
-            <CheckCircleIcon className="w-4 h-5 mt-1 ml-1 stroke-2" />
+            <CheckCircleIcon className="w-4 h-5 mt-1 ml-1 text-green-500" />
           ) : remainingCredits === 0 ? (
-            <ExclamationIcon className="w-4 h-5 mt-1 ml-1 stroke-2" />
+            <ExclamationIcon className="w-4 h-5 mt-1 ml-1 text-red-500" />
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
### Description (User Stories)
As a user, I want to make note of distribution requirements that my plan has not yet fulfilled so that I can plan accordingly. A user wishes errors in the Tracker are more obvious. A possible solution is making the error icon red and making the check icon green.

### Implementation
before :
![image](https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/e8830dd7-b31d-4caa-bb87-1c1ed98952c9)
after :
<img width="245" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/435af66b-b2b8-475f-b56e-7d007f7c8a83">
<img width="232" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/fffc2170-76d9-4ee9-8508-966e02846838">