### PR TITLE
DEV-198 default values for placeholder courses

### DIFF
--- a/lib/components/popups/course-search/query-components/SearchList.tsx
+++ b/lib/components/popups/course-search/query-components/SearchList.tsx
@@ -98,17 +98,17 @@ const SearchList: FC<{
       const placeholderCourse: Course = {
         title: 'placeholder',
         number: 'placeholder',
-        areas: '',
+        areas: 'none',
         term: '',
         school: 'none',
         department: 'none',
-        credits: '',
+        credits: '0',
         wi: false,
         bio: 'This is a placeholder course',
-        tags: [],
+        tags: ['none'],
         preReq: [],
         restrictions: [],
-        level: '',
+        level: 'Lower Level Undergraduate',
       };
       dispatch(updatePlaceholder(true));
       dispatch(updateInspectedVersion(placeholderCourse));

--- a/lib/components/popups/course-search/search-results/Placeholder.tsx
+++ b/lib/components/popups/course-search/search-results/Placeholder.tsx
@@ -342,7 +342,7 @@ const Placeholder: FC<{ addCourse: (plan?: Plan) => void }> = (props) => {
             </div>
           </div>
           <Select
-            options={['none', 'N', 'S', 'H', 'E', 'Q'].map((area: any) => ({
+            options={['None', 'N', 'S', 'H', 'E', 'Q'].map((area: any) => ({
               label: area,
               value: area,
             }))}

--- a/lib/components/popups/course-search/search-results/Placeholder.tsx
+++ b/lib/components/popups/course-search/search-results/Placeholder.tsx
@@ -342,7 +342,7 @@ const Placeholder: FC<{ addCourse: (plan?: Plan) => void }> = (props) => {
             </div>
           </div>
           <Select
-            options={['None', 'N', 'S', 'H', 'E', 'Q'].map((area: any) => ({
+            options={['none', 'N', 'S', 'H', 'E', 'Q'].map((area: any) => ({
               label: area,
               value: area,
             }))}
@@ -368,7 +368,6 @@ const Placeholder: FC<{ addCourse: (plan?: Plan) => void }> = (props) => {
             options={[
               'Lower Level Undergraduate',
               'Upper Level Undergraduate',
-              'none',
             ].map((option: string) => ({
               label: option,
               value: option,


### PR DESCRIPTION
### Description & Implementation
- default values for placeholder area, credits, tags, & level to save a couple clicks for users
before: 
<img width="271" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/0197f781-6eed-477e-ad7d-b44a430d27d2">

after: 
<img width="256" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/e205de96-6af3-427c-b339-02b79061d31e">

- remove 'none' option for level (now the only options are lower and upper level) because we have an error message if the user selects 'none' for level anyways
before: 
<img width="209" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/841ce2fc-3042-4459-b03c-22547538071d">
<img width="305" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/43786620/90355f60-f852-49ab-9af0-741a5c4cd21a">

- made 'none' option lowercase for areas to keep consistent with other placeholder fields