### PR TITLE
Bug: Fix prereq display properly updating when prereq selected 

### DIFF
--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -8,10 +8,8 @@ import { allMajors } from '../../resources/majors';
 import Tooltip from '@mui/material/Tooltip';
 import {
   selectPlan,
-  selectSelectedMajor,
   updateSelectedPlan,
   updateCurrentPlanCourses,
-  updateSelectedMajor,
 } from '../../slices/currentPlanSlice';
 import {
   updateAddingPlanStatus,
@@ -47,7 +45,6 @@ const majorOptions = allMajors.map((major) => ({
 const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
   const planList = useSelector(selectPlanList);
   const currentPlan = useSelector(selectPlan);
-  const newSelectedMajor = useSelector(selectSelectedMajor);
   const user = useSelector(selectUser);
   const token = useSelector(selectToken);
   const dispatch = useDispatch();

--- a/lib/components/dashboard/Actionbar.tsx
+++ b/lib/components/dashboard/Actionbar.tsx
@@ -173,11 +173,6 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
       if (currentPlan.majors.includes(major.name))
         currentMajorOptions.push({ label: major.name, value: major.abbrev });
     });
-    if (newSelectedMajor) {
-      if (currentPlan.majors.includes(newSelectedMajor.degree_name)) {
-        dispatch(updateSelectedMajor(newSelectedMajor));
-      }
-    }
     return currentMajorOptions;
   };
 
@@ -298,7 +293,6 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
           </Dialog>
           <Autocomplete
             disablePortal
-            id="combo-box-demo"
             options={[
               { value: currentPlan, label: 'Create New Plan' },
               ...planList
@@ -324,7 +318,6 @@ const Actionbar: FC<{ mode: ReviewMode }> = ({ mode }) => {
           <Autocomplete
             disablePortal
             multiple
-            id="combo-box-demo"
             options={majorOptions.map((option, i) => ({
               label: option.name,
               value: option.abbrev,

--- a/lib/components/dashboard/menus/comments/CommentsOverview.tsx
+++ b/lib/components/dashboard/menus/comments/CommentsOverview.tsx
@@ -37,7 +37,13 @@ const CommentsOverview: React.FC = () => {
       }
     }
     setNumComments(comments);
-    const ts = temp.map((e) => getComments(e));
+    const ts = temp.map((e) => {
+      return (
+        <div key={e._id}>
+          { getComments(e) }
+        </div>
+      )
+    });
     setThreadJSX(ts);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadObjs]);

--- a/lib/components/dashboard/menus/comments/CommentsOverview.tsx
+++ b/lib/components/dashboard/menus/comments/CommentsOverview.tsx
@@ -38,11 +38,7 @@ const CommentsOverview: React.FC = () => {
     }
     setNumComments(comments);
     const ts = temp.map((e) => {
-      return (
-        <div key={e._id}>
-          { getComments(e) }
-        </div>
-      )
+      return <div key={e._id}>{getComments(e)}</div>;
     });
     setThreadJSX(ts);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/lib/components/popups/course-search/postreqs/PostReqSection.tsx
+++ b/lib/components/popups/course-search/postreqs/PostReqSection.tsx
@@ -7,19 +7,19 @@ import {
   selectVersion,
   selectInspectedCourse,
 } from '../../../../slices/searchSlice';
-import { getCourse, getCourseYear } from '../../../../resources/assets';
+import {
+  getCourse,
+  getCourseYear,
+  getSISCourse,
+} from '../../../../resources/assets';
 import {
   selectCurrentPlanCourses,
   selectPlan,
 } from '../../../../slices/currentPlanSlice';
 import { selectCourseCache } from '../../../../slices/userSlice';
 import { selectCourseToShow } from '../../../../slices/popupSlice';
-import {
-  SISRetrievedCourse,
-  UserCourse,
-  Year,
-  PostReq,
-} from '../../../../resources/commonTypes';
+import { UserCourse, Year, PostReq } from '../../../../resources/commonTypes';
+import { toast } from 'react-toastify';
 
 const PostReqSection: FC = () => {
   const dispatch = useDispatch();
@@ -112,6 +112,7 @@ const PostReqSection: FC = () => {
     }
     const tempSatisfiedPostReqs: PostReq[] = [];
     const tempUnsatisfiedPostReqs: PostReq[] = [];
+    if (!postReqs) return;
     postReqs.forEach((course, index) => {
       getCourse(course.number, courseCache, currPlanCourses, index);
       if (checkIfSatisfied(course)) {
@@ -235,12 +236,8 @@ const PostReqSection: FC = () => {
   const updateInspected =
     (courseNumber: string): (() => void) =>
     (): void => {
-      courseCache.forEach((course: SISRetrievedCourse) => {
-        if (
-          course.number === courseNumber &&
-          inspected !== 'None' &&
-          version !== 'None'
-        ) {
+      getSISCourse(courseNumber, courseCache).then((course) => {
+        if (course != null && inspected !== 'None' && version !== 'None') {
           dispatch(
             updateSearchStack({
               new: course,
@@ -248,6 +245,10 @@ const PostReqSection: FC = () => {
               oldV: version,
             }),
           );
+        } else if (course == null) {
+          toast.error('Cannot find course. It likely does not exist.', {
+            toastId: 'course not found',
+          });
         }
       });
     };

--- a/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
+++ b/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
@@ -22,7 +22,6 @@ import {
 import { selectCourseCache } from '../../../../slices/userSlice';
 import { selectCourseToShow } from '../../../../slices/popupSlice';
 import {
-  SISRetrievedCourse,
   UserCourse,
   Year,
 } from '../../../../resources/commonTypes';

--- a/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
+++ b/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
@@ -21,10 +21,7 @@ import {
 } from '../../../../slices/currentPlanSlice';
 import { selectCourseCache } from '../../../../slices/userSlice';
 import { selectCourseToShow } from '../../../../slices/popupSlice';
-import {
-  UserCourse,
-  Year,
-} from '../../../../resources/commonTypes';
+import { UserCourse, Year } from '../../../../resources/commonTypes';
 import { toast } from 'react-toastify';
 
 // Parsed prereq type

--- a/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
+++ b/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
@@ -158,12 +158,12 @@ const PrereqDisplay: FC = () => {
               oldSIS: inspected,
               oldV: version,
             }),
-          )
+          );
         } else if (course == null) {
           toast.error('Cannot find course. It likely does not exist.', {
             toastId: 'course not found',
           });
-        };
+        }
       });
     };
 

--- a/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
+++ b/lib/components/popups/course-search/prereqs/PrereqDisplay.tsx
@@ -12,6 +12,7 @@ import {
   filterNNegatives,
   processPrereqs,
   checkPrereq,
+  getSISCourse,
 } from '../../../../resources/assets';
 import PrereqDropdown from './PrereqDropdown';
 import {
@@ -25,6 +26,7 @@ import {
   UserCourse,
   Year,
 } from '../../../../resources/commonTypes';
+import { toast } from 'react-toastify';
 
 // Parsed prereq type
 // satisfied: a boolean that tells whether the prereq should be marked with green (satisfied) or red (unsatisfied)
@@ -148,20 +150,20 @@ const PrereqDisplay: FC = () => {
   const updateInspected =
     (courseNumber: string): (() => void) =>
     (): void => {
-      courseCache.forEach((course: SISRetrievedCourse) => {
-        if (
-          course.number === courseNumber &&
-          inspected !== 'None' &&
-          version !== 'None'
-        ) {
+      getSISCourse(courseNumber, courseCache).then((course) => {
+        if (course != null && inspected !== 'None' && version !== 'None') {
           dispatch(
             updateSearchStack({
               new: course,
               oldSIS: inspected,
               oldV: version,
             }),
-          );
-        }
+          )
+        } else if (course == null) {
+          toast.error('Cannot find course. It likely does not exist.', {
+            toastId: 'course not found',
+          });
+        };
       });
     };
 

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -520,6 +520,37 @@ export const getCourse = async (
     // Then pull from db.
     return resolve(await backendSearch(courseNumber, indexNum, userC));
   });
+  
+export const getSISCourse = async (
+  courseNumber: string,
+  courseCache: SISRetrievedCourse[]
+) : Promise<SISRetrievedCourse | null> => 
+  new Promise(async (resolve) => {
+    let out: SISRetrievedCourse;
+    for (let element of courseCache) {
+      if (element.number === courseNumber) {
+        out = element;
+        return resolve(out);
+      }
+    }
+    // fetch from backend
+    try {
+      const res: any = await axios.get(
+        getAPI(window) + `/searchNumber/${courseNumber}`,
+      );
+      let retrieved: SISRetrievedCourse | -1 = res.data.data;
+      if (retrieved === -1) {
+        store.dispatch(updateUnfoundNumbers(courseNumber));
+        return resolve(null);
+      }
+      const cache: SISRetrievedCourse[] = [];
+      cache.push(retrieved);
+      store.dispatch(updateCourseCache(cache));
+      resolve(retrieved);
+    } catch (err) {
+      return resolve(null);
+    }
+  });
 
 const backendSearch = async (
   courseNumber: string,

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -521,36 +521,35 @@ export const getCourse = async (
     return resolve(await backendSearch(courseNumber, indexNum, userC));
   });
 
-export const getSISCourse = async (
+export const getSISCourse = (
   courseNumber: string,
   courseCache: SISRetrievedCourse[],
-): Promise<SISRetrievedCourse | null> =>
-  new Promise(async (resolve) => {
-    let out: SISRetrievedCourse;
+): Promise<SISRetrievedCourse | null> => {
+  return new Promise((resolve) => {
     for (let element of courseCache) {
       if (element.number === courseNumber) {
-        out = element;
-        return resolve(out);
+        resolve(element);
+        return;
       }
     }
     // fetch from backend
-    try {
-      const res: any = await axios.get(
-        getAPI(window) + `/searchNumber/${courseNumber}`,
-      );
-      let retrieved: SISRetrievedCourse | -1 = res.data.data;
-      if (retrieved === -1) {
-        store.dispatch(updateUnfoundNumbers(courseNumber));
-        return resolve(null);
-      }
-      const cache: SISRetrievedCourse[] = [];
-      cache.push(retrieved);
-      store.dispatch(updateCourseCache(cache));
-      resolve(retrieved);
-    } catch (err) {
-      return resolve(null);
-    }
+    axios
+      .get(getAPI(window) + `/searchNumber/${courseNumber}`)
+      .then((res) => {
+        let retrieved: SISRetrievedCourse | -1 = res.data.data;
+        if (retrieved === -1) {
+          store.dispatch(updateUnfoundNumbers(courseNumber));
+          resolve(null);
+        } else {
+          store.dispatch(updateCourseCache([retrieved]));
+          resolve(retrieved);
+        }
+      })
+      .catch((err) => {
+        resolve(null);
+      });
   });
+};
 
 const backendSearch = async (
   courseNumber: string,

--- a/lib/resources/assets.tsx
+++ b/lib/resources/assets.tsx
@@ -520,11 +520,11 @@ export const getCourse = async (
     // Then pull from db.
     return resolve(await backendSearch(courseNumber, indexNum, userC));
   });
-  
+
 export const getSISCourse = async (
   courseNumber: string,
-  courseCache: SISRetrievedCourse[]
-) : Promise<SISRetrievedCourse | null> => 
+  courseCache: SISRetrievedCourse[],
+): Promise<SISRetrievedCourse | null> =>
   new Promise(async (resolve) => {
     let out: SISRetrievedCourse;
     for (let element of courseCache) {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@amplitude/analytics-browser": "^1.8.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@emailjs/browser": "^3.10.0",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",


### PR DESCRIPTION
### Description
Found a bug where clicking a course's prereq (see picture) wouldn't change the display to show that course unless it was in the current course cache. If it wasn't in the cache, it would just not do anything :(
<img width="632" alt="image" src="https://github.com/uCredit-Dev/ucredit_frontend_typescript/assets/89751747/40993d51-14fe-409a-aff7-ada61cbf7a09">

### Fixes
Added a method in `assets.tsx` that searches the course cache for a given course number and if it's not there, retrieves it from the backend and adds it to the existing course. (Or returns `null` if it's nowhere to be found in these locations).
Changed `updateInspected` in `PrereqDisplay.tsx` to call this method instead of exclusively looping through course cache. If the course is found, the updates follow (as they did previously). If not, a toast is used to indicate error.

i haven't written code or made a pr in like a century i hope this wasn't horrible thanks :heart:
also idk how to address the remaining solarcloud issues, they seem to have existed before this pr